### PR TITLE
fix Query() returning wrong address when a repeater answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Hugo Arregui](https://github.com/hugoArregui)
 * [Atsushi Watanabe](https://github.com/at-wat)
 * [Doug Cone](https://github.com/nullvariable)
+* [Javier Peletier](https://github.com/jpeletier)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
#### Description

This PR fixes an issue that happens when a mDNS query is broadcast and a repeater answers instead or before the real host. In this situation, the original code wrongly returns the address of the repeater.

The new code actually parses the DNS response UDP packet to find the answer. This works with and without repeaters.
