### PR TITLE
Add configuration option to allow overriding the published IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ For a mDNS server that responds to queries for `pion-test.local`
 go run examples/server/main.go
 ```
 
+For a mDNS server that responds to queries for `pion-test.local` with a given address
+```sh
+go run examples/server/publish_ip/main.go -ip=[IP]
+```
+If you don't set the `ip` parameter, "1.2.3.4" will be used instead.
+
 
 ### Running Client
 To query using Pion you can run the `query` example

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package mdns
 
 import (
+	"net"
 	"time"
 
 	"github.com/pion/logging"
@@ -22,6 +23,10 @@ type Config struct {
 	// LocalNames are the names that we will generate answers for
 	// when we get questions
 	LocalNames []string
+
+	// LocalAddress will override the published address with the given IP
+	// when set. Otherwise, the automatically determined address will be used.
+	LocalAddress net.IP
 
 	LoggerFactory logging.LoggerFactory
 }

--- a/examples/server/publish_ip/main.go
+++ b/examples/server/publish_ip/main.go
@@ -1,0 +1,35 @@
+// This example program allows to set an IP that deviates from the automatically determined interface address.
+// Use the "-ip" parameter to set an IP. If not set, the example server defaults to "1.2.3.4".
+package main
+
+import (
+	"flag"
+	"net"
+
+	"github.com/pion/mdns"
+	"golang.org/x/net/ipv4"
+)
+
+func main() {
+	ip := flag.String("ip", "1.2.3.4", "IP address to be published")
+	flag.Parse()
+
+	addr, err := net.ResolveUDPAddr("udp", mdns.DefaultAddress)
+	if err != nil {
+		panic(err)
+	}
+
+	l, err := net.ListenUDP("udp4", addr)
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = mdns.Server(ipv4.NewPacketConn(l), &mdns.Config{
+		LocalNames:   []string{"pion-test.local"},
+		LocalAddress: net.ParseIP(*ip),
+	})
+	if err != nil {
+		panic(err)
+	}
+	select {}
+}


### PR DESCRIPTION
#### Description
This pull request adds the ability to set an IP (either IPv4 or IPv6) to be published for a given list of "LocalNames" instead of publishing the automatically determined interface address. One use case for this functionality is to publish local addresses used in development environments without requiring awkward workarounds like altering the /etc/hosts file, for example. Another benefit of this solution is that it gives the user more control in cases where multiple interfaces are present on the machine. However, tying the address to an existing interface is not the goal here. The reasoning behind this is that such a limitation would greatly limit the usefulness of the feature for the use case described above (publishing the address of a dev vm).

In addition to the above described changes, the following steps were taken to ensure that the code quality is as expected:
- Tests cover the new functionality and another example has also been added for convenience. 
- The documentation (README) was updated as well. 
- All local checks mentioned in the [contributing wiki](https://github.com/pion/webrtc/wiki/Contributing) that are part of this repo were run successfully.

@Sean-Der: As mentioned on Slack, please let me know if this PR is ok from your point of view. It would be very helpful to get this feature added. Thanks in advance!


#### Reference issue
Fixes #92 
