### PR TITLE
Add config option to set published address

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ For a mDNS server that responds to queries for `pion-test.local`
 go run examples/server/main.go
 ```
 
+For a mDNS server that responds to queries for `pion-test.local` with a given address
+```sh
+go run examples/server/publish_ip/main.go -ip=[IP]
+```
+If you don't set the `ip` parameter, "1.2.3.4" will be used instead.
+
 
 ### Running Client
 To query using Pion you can run the `query` example

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package mdns
 
 import (
+	"net"
 	"time"
 
 	"github.com/pion/logging"
@@ -22,6 +23,10 @@ type Config struct {
 	// LocalNames are the names that we will generate answers for
 	// when we get questions
 	LocalNames []string
+
+	// LocalAddress will override the published address with the given IP
+	// when set. Otherwise, the automatically determined address will be used.
+	LocalAddress net.IP
 
 	LoggerFactory logging.LoggerFactory
 }

--- a/examples/query/main.go
+++ b/examples/query/main.go
@@ -1,3 +1,4 @@
+// This example program showcases the use of the mDNS client by querying a previously published address
 package main
 
 import (

--- a/examples/server/publish_ip/main.go
+++ b/examples/server/publish_ip/main.go
@@ -1,7 +1,9 @@
-// This example program showcases the use of the mDNS server by publishing "pion-test.local"
+// This example program allows to set an IP that deviates from the automatically determined interface address.
+// Use the "-ip" parameter to set an IP. If not set, the example server defaults to "1.2.3.4".
 package main
 
 import (
+	"flag"
 	"net"
 
 	"github.com/pion/mdns"
@@ -9,6 +11,9 @@ import (
 )
 
 func main() {
+	ip := flag.String("ip", "1.2.3.4", "IP address to be published")
+	flag.Parse()
+
 	addr, err := net.ResolveUDPAddr("udp", mdns.DefaultAddress)
 	if err != nil {
 		panic(err)
@@ -20,7 +25,8 @@ func main() {
 	}
 
 	_, err = mdns.Server(ipv4.NewPacketConn(l), &mdns.Config{
-		LocalNames: []string{"pion-test.local"},
+		LocalNames:   []string{"pion-test.local"},
+		LocalAddress: net.ParseIP(*ip),
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This commit adds the parameter `LocalAddress` to the `Config` struct. The change allows to manually override the published address. A valid address can either be an IPv4 or IPv6 address.

#### Description
As described in the commit, a new parameter "LocalAddress" now allows to manually override the advertised address. A new test case was added to cover the feature. Linting did not reveal any further issues. I also added a few short comments to the example programs in order to get rid of warnings issued by `golangci-lint run`.

#### Reference issue
Fixes #92 
