### PR TITLE
Support dig based unicast requests

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -659,7 +659,7 @@ func TestResourceParsing(t *testing.T) {
 	name := "test-server."
 
 	t.Run("A Record", func(t *testing.T) {
-		answer, err := createAnswer(name, net.IP{127, 0, 0, 1})
+		answer, err := createAnswer(1, name, net.IP{127, 0, 0, 1})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -667,15 +667,7 @@ func TestResourceParsing(t *testing.T) {
 	})
 
 	t.Run("AAAA Record", func(t *testing.T) {
-		// because it's compatible
-		answer, err := createAnswer(name, net.ParseIP("127.0.0.1"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		// this is wrong...?
-		lookForIP(answer, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 0, 0, 1}, t)
-
-		answer, err = createAnswer(name, net.ParseIP("::1"))
+		answer, err := createAnswer(1, name, net.ParseIP("::1"))
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
e.g. dig -p 5353 @224.0.0.251 pion-test.local

#### Description
I noticed this wasn't supported after getting IPv6/unicast support in. The basic issue was 1. not using the ID that the question came from in the answer and 2. not supporting legacy resolvers (technically like ourselves as a non-continuous querier)