### PR TITLE
Sending the question back with the answer

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -704,9 +704,10 @@ func TestResourceParsing(t *testing.T) {
 	}
 
 	name := "test-server."
+	q := dnsmessage.Question{Name: dnsmessage.MustNewName(name)}
 
 	t.Run("A Record", func(t *testing.T) {
-		answer, err := createAnswer(1, name, mustAddr(net.IP{127, 0, 0, 1}))
+		answer, err := createAnswer(1, q, mustAddr(net.IP{127, 0, 0, 1}))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -714,7 +715,7 @@ func TestResourceParsing(t *testing.T) {
 	})
 
 	t.Run("AAAA Record", func(t *testing.T) {
-		answer, err := createAnswer(1, name, netip.MustParseAddr("::1"))
+		answer, err := createAnswer(1, q, netip.MustParseAddr("::1"))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/examples/query/main.go
+++ b/examples/query/main.go
@@ -10,7 +10,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/pion/mdns/v2"
+	"github.com/atomirex/mdns"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
 )

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -7,7 +7,7 @@ package main
 import (
 	"net"
 
-	"github.com/pion/mdns/v2"
+	"github.com/atomirex/mdns"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
 )

--- a/examples/server/publish_ip/main.go
+++ b/examples/server/publish_ip/main.go
@@ -9,7 +9,7 @@ import (
 	"flag"
 	"net"
 
-	"github.com/pion/mdns/v2"
+	"github.com/atomirex/mdns"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pion/mdns/v2
+module github.com/atomirex/mdns
 
 go 1.20
 


### PR DESCRIPTION
#### Description
This includes the question that provoked the answer in the response containing the answer.

This enables Android clients to resolve hostname.local domains published with this package.

#### Reference issue
This is necessary for certain mdns clients (the Android dnsresolver, primarily) to pick up the answer to their question. This was established by inspecting what Bonjour was doing on a Mac which allowed it to be recognised. (The Mac will also do things like bundle A and AAAA responses for ipv4 and ipv6, but that didn't prove to be necessary to resolve my problem).


This is more for reference of the bug and change made than a serious request this be merged.