### PR TITLE
Stop skipping most IPv6 tests

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -269,9 +269,6 @@ func TestValidCommunicationIPv6(t *testing.T) { //nolint:cyclop
 }
 
 func TestValidCommunicationIPv46(t *testing.T) {
-	if runtime.GOARCH == "386" {
-		t.Skip("IPv6 not supported on 386 for some reason")
-	}
 
 	lim := test.TimeOut(time.Second * 10)
 	defer lim.Stop()
@@ -309,9 +306,6 @@ func TestValidCommunicationIPv46(t *testing.T) {
 }
 
 func TestValidCommunicationIPv46Mixed(t *testing.T) {
-	if runtime.GOARCH == "386" {
-		t.Skip("IPv6 not supported on 386 for some reason")
-	}
 
 	lim := test.TimeOut(time.Second * 10)
 	defer lim.Stop()
@@ -355,9 +349,6 @@ func TestValidCommunicationIPv46Mixed(t *testing.T) {
 }
 
 func TestValidCommunicationIPv46MixedLocalAddress(t *testing.T) {
-	if runtime.GOARCH == "386" {
-		t.Skip("IPv6 not supported on 386 for some reason")
-	}
 
 	lim := test.TimeOut(time.Second * 10)
 	defer lim.Stop()
@@ -393,9 +384,6 @@ func TestValidCommunicationIPv46MixedLocalAddress(t *testing.T) {
 }
 
 func TestValidCommunicationIPv66Mixed(t *testing.T) {
-	if runtime.GOARCH == "386" {
-		t.Skip("IPv6 not supported on 386 for some reason")
-	}
 
 	lim := test.TimeOut(time.Second * 10)
 	defer lim.Stop()
@@ -429,9 +417,6 @@ func TestValidCommunicationIPv66Mixed(t *testing.T) {
 }
 
 func TestValidCommunicationIPv66MixedLocalAddress(t *testing.T) {
-	if runtime.GOARCH == "386" {
-		t.Skip("IPv6 not supported on 386 for some reason")
-	}
 
 	lim := test.TimeOut(time.Second * 10)
 	defer lim.Stop()
@@ -467,9 +452,6 @@ func TestValidCommunicationIPv66MixedLocalAddress(t *testing.T) {
 }
 
 func TestValidCommunicationIPv64Mixed(t *testing.T) {
-	if runtime.GOARCH == "386" {
-		t.Skip("IPv6 not supported on 386 for some reason")
-	}
 
 	lim := test.TimeOut(time.Second * 10)
 	defer lim.Stop()


### PR DESCRIPTION
IPv6 is now supported in docker (pion/.goassets commit ee7a4d8) so we can stop skipping IPv6 tests.

`TestValidCommunicationIPv6` is still skipped because it still fails. A separate bug/PR will be opened to address that.