### PR TITLE
Set zone for IPv6 ULA addresses

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1299,7 +1299,7 @@ func addrWithOptionalZone(addr netip.Addr, zone string) netip.Addr {
 	if zone == "" {
 		return addr
 	}
-	if addr.Is6() && (addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast()) {
+	if addr.Is6() && (addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() || addr.IsPrivate()) {
 		return addr.WithZone(zone)
 	}
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"net"
 	"net/netip"
-	"runtime"
 	"testing"
 	"time"
 
@@ -213,9 +212,6 @@ func TestValidCommunicationWithLoopbackInterface(t *testing.T) {
 }
 
 func TestValidCommunicationIPv6(t *testing.T) { //nolint:cyclop
-	if runtime.GOARCH == "386" {
-		t.Skip("IPv6 not supported on 386 for some reason")
-	}
 	lim := test.TimeOut(time.Second * 10)
 	defer lim.Stop()
 


### PR DESCRIPTION
`addrWithOptionalZone` only adds the name of the zone when the IPv6 address is link-local unicast or broadcast. This causes tests to fail when an IPv6 Unique Local Address (ULA) address (`fc00::/7`) is chosen.

ULA addresses are the moral equivalent of IPv4 private RFC1918 addresses, so it makes sense to have mDNS zones set for these IPs.

There appears to be a mismatch in the expectations of the test and the implementation: The implementation chooses the first real IPv6 address it receives from the IPs assigned to the interface while the test code expects a Zone to be set, which only happens for link-local (and now ULA) addresses. This will be addressed in a follow-up bug/PR.

For now, this PR enables tests to run in environments where the selected address is a ULA address (such as my personal computer and the docker containers used for testing).