### PR TITLE
Integrate record cache into event loop (write side)

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -286,12 +286,14 @@ func newRefreshJitter() float64 {
 	return rand.Float64() * maxRefreshJitter //nolint:gosec // weak random is fine for jitter
 }
 
-// dueForRefresh checks the given cache keys and returns those with entries
-// that have reached their next refresh threshold (RFC 6762 §5.2).
-// Duplicate keys are checked once. For each returned candidate,
-// refreshesSent is incremented; entries with originalTTL = 0 (goodbyes)
-// are skipped and at most four refreshes are sent per entry per TTL.
-func (c *cache) dueForRefresh(keys []cacheKey) []cacheKey {
+// takeRefreshCandidates consumes and returns the keys with entries that
+// have reached their next refresh threshold (RFC 6762 §5.2). Each returned
+// candidate has its refreshesSent counter incremented under the cache lock,
+// so a key is handed out at most once per threshold; the caller is expected
+// to send the refresh query. Duplicate keys are checked once. Entries with
+// originalTTL = 0 (goodbyes) are skipped and at most four refreshes are
+// handed out per entry per TTL.
+func (c *cache) takeRefreshCandidates(keys []cacheKey) []cacheKey {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/cache.go
+++ b/cache.go
@@ -4,6 +4,7 @@
 package mdns
 
 import (
+	"math/rand"
 	"strings"
 	"sync"
 	"time"
@@ -33,9 +34,11 @@ type cacheKey struct {
 
 // cacheEntry stores one cached resource record with timing metadata.
 type cacheEntry struct {
-	resource  dnsmessage.Resource
-	createdAt time.Time
-	expiresAt time.Time
+	resource      dnsmessage.Resource
+	createdAt     time.Time
+	expiresAt     time.Time
+	originalTTL   time.Duration
+	refreshesSent uint8
 }
 
 // cache is a thread-safe mDNS record cache (RFC 6762 §10).
@@ -96,6 +99,8 @@ func (c *cache) insertGoodbye(key cacheKey, res dnsmessage.Resource, receivedAt 
 	for idx := range entries {
 		if resourceDataEqual(entries[idx].resource, res) {
 			entries[idx].expiresAt = receivedAt.Add(goodbyeTTL)
+			entries[idx].originalTTL = goodbyeTTL
+			entries[idx].refreshesSent = 0
 
 			return
 		}
@@ -105,9 +110,10 @@ func (c *cache) insertGoodbye(key cacheKey, res dnsmessage.Resource, receivedAt 
 	// the goodbye briefly before it expires.
 	res.Header.TTL = 1
 	c.entries[key] = append(entries, cacheEntry{
-		resource:  res,
-		createdAt: receivedAt,
-		expiresAt: receivedAt.Add(goodbyeTTL),
+		resource:    res,
+		createdAt:   receivedAt,
+		expiresAt:   receivedAt.Add(goodbyeTTL),
+		originalTTL: goodbyeTTL,
 	})
 }
 
@@ -135,15 +141,18 @@ func (c *cache) insertOrUpdate(key cacheKey, res dnsmessage.Resource, receivedAt
 			entries[idx].resource.Header.TTL = res.Header.TTL
 			entries[idx].createdAt = receivedAt
 			entries[idx].expiresAt = receivedAt.Add(ttl)
+			entries[idx].originalTTL = ttl
+			entries[idx].refreshesSent = 0
 
 			return
 		}
 	}
 
 	c.entries[key] = append(entries, cacheEntry{
-		resource:  res,
-		createdAt: receivedAt,
-		expiresAt: receivedAt.Add(ttl),
+		resource:    res,
+		createdAt:   receivedAt,
+		expiresAt:   receivedAt.Add(ttl),
+		originalTTL: ttl,
 	})
 }
 
@@ -199,6 +208,63 @@ func (c *cache) sweep() {
 			c.entries[key] = alive
 		}
 	}
+}
+
+// refreshThresholds returns the fractions of TTL at which refresh queries
+// are sent (RFC 6762 §5.2): 80%, 85%, 90%, 95%.
+func refreshThresholds() [4]float64 {
+	return [4]float64{0.80, 0.85, 0.90, 0.95}
+}
+
+// maxRefreshJitter is the maximum random jitter added to each threshold.
+const maxRefreshJitter = 0.02
+
+// refreshCandidate identifies a cache entry that needs a refresh query.
+type refreshCandidate struct {
+	name    string
+	rrType  dnsmessage.Type
+	rrClass dnsmessage.Class
+}
+
+// dueForRefresh checks the given cache keys and returns entries that have
+// reached their next refresh threshold. For each returned candidate,
+// refreshesSent is incremented. Only entries with originalTTL > 0 and
+// fewer than 4 refreshes sent are considered.
+func (c *cache) dueForRefresh(keys []cacheKey) []refreshCandidate {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.now()
+	var candidates []refreshCandidate
+
+	for _, key := range keys {
+		entries := c.entries[key]
+
+		for idx := range entries {
+			entry := &entries[idx]
+			if entry.originalTTL <= 0 || entry.refreshesSent >= 4 {
+				continue
+			}
+
+			if !now.Before(entry.expiresAt) {
+				continue
+			}
+
+			startedAt := entry.expiresAt.Add(-entry.originalTTL)
+			elapsed := now.Sub(startedAt)
+			fraction := float64(elapsed) / float64(entry.originalTTL)
+
+			//nolint:gosec // weak random is fine for jitter
+			threshold := refreshThresholds()[entry.refreshesSent] + rand.Float64()*maxRefreshJitter
+
+			if fraction >= threshold {
+				candidates = append(candidates, refreshCandidate(key))
+				entry.refreshesSent++
+			}
+		}
+	}
+
+	return candidates
 }
 
 // flushAll drops all entries (RFC 6762 §10.3 topology change).

--- a/cache.go
+++ b/cache.go
@@ -290,7 +290,9 @@ func newRefreshJitter() float64 {
 // have reached their next refresh threshold (RFC 6762 §5.2). Each returned
 // candidate has its refreshesSent counter incremented under the cache lock,
 // so a key is handed out at most once per threshold; the caller is expected
-// to send the refresh query. Duplicate keys are checked once. Entries with
+// to send the refresh query. Duplicate keys are checked once and a key is
+// returned at most once per call, even when several entries under it are
+// due (one question refreshes all records for the key). Entries with
 // originalTTL = 0 (goodbyes) are skipped and at most four refreshes are
 // handed out per entry per TTL.
 func (c *cache) takeRefreshCandidates(keys []cacheKey) []cacheKey {
@@ -310,6 +312,7 @@ func (c *cache) takeRefreshCandidates(keys []cacheKey) []cacheKey {
 		seen[key] = struct{}{}
 
 		entries := c.entries[key]
+		keyAdded := false
 		for idx := range entries {
 			entry := &entries[idx]
 			if entry.originalTTL <= 0 || int(entry.refreshesSent) >= len(thresholds) {
@@ -324,7 +327,10 @@ func (c *cache) takeRefreshCandidates(keys []cacheKey) []cacheKey {
 			fraction := float64(now.Sub(startedAt)) / float64(entry.originalTTL)
 
 			if fraction >= thresholds[entry.refreshesSent]+entry.refreshJitter {
-				candidates = append(candidates, key)
+				if !keyAdded {
+					candidates = append(candidates, key)
+					keyAdded = true
+				}
 				entry.refreshesSent++
 				entry.refreshJitter = newRefreshJitter()
 			}

--- a/cache.go
+++ b/cache.go
@@ -24,6 +24,16 @@ const goodbyeTTL = 1 * time.Second
 // after receiving a cache-flush response (RFC 6762 §10.2).
 const cacheFlushDelay = 1 * time.Second
 
+// maxRecordTTL caps the lifetime of cached records. RFC 6762 §10
+// recommends TTLs of 75 minutes or less; clamping protects against
+// hostile or misconfigured responders advertising near-immortal records.
+const maxRecordTTL = 75 * time.Minute
+
+// maxCacheEntries caps the total number of cached records so that a busy
+// or hostile network cannot grow the cache without bound. When full, the
+// entry closest to expiry is evicted to make room.
+const maxCacheEntries = 4096
+
 // cacheKey identifies a set of records by lowercased name, type, and
 // class (with the cache-flush bit masked).
 type cacheKey struct {
@@ -38,6 +48,7 @@ type cacheEntry struct {
 	createdAt     time.Time
 	expiresAt     time.Time
 	originalTTL   time.Duration
+	refreshJitter float64
 	refreshesSent uint8
 }
 
@@ -45,6 +56,7 @@ type cacheEntry struct {
 type cache struct {
 	mu      sync.RWMutex
 	entries map[cacheKey][]cacheEntry
+	size    int
 	now     func() time.Time
 }
 
@@ -93,14 +105,14 @@ func (c *cache) insert(res dnsmessage.Resource, receivedAt time.Time) {
 
 // insertGoodbye handles a record with TTL=0 (RFC 6762 §10.1).
 // If a matching record exists, its expiry is set to now+1s.
-// Otherwise a new entry is created with a 1s TTL.
+// Otherwise a new entry is created with a 1s TTL. Goodbye entries
+// keep originalTTL=0 so they are never refresh candidates.
 func (c *cache) insertGoodbye(key cacheKey, res dnsmessage.Resource, receivedAt time.Time) {
 	entries := c.entries[key]
 	for idx := range entries {
 		if resourceDataEqual(entries[idx].resource, res) {
 			entries[idx].expiresAt = receivedAt.Add(goodbyeTTL)
-			entries[idx].originalTTL = goodbyeTTL
-			entries[idx].refreshesSent = 0
+			entries[idx].originalTTL = 0
 
 			return
 		}
@@ -109,11 +121,10 @@ func (c *cache) insertGoodbye(key cacheKey, res dnsmessage.Resource, receivedAt 
 	// Unknown record: insert with 1s TTL so that late listeners see
 	// the goodbye briefly before it expires.
 	res.Header.TTL = 1
-	c.entries[key] = append(entries, cacheEntry{
-		resource:    res,
-		createdAt:   receivedAt,
-		expiresAt:   receivedAt.Add(goodbyeTTL),
-		originalTTL: goodbyeTTL,
+	c.appendEntry(key, cacheEntry{
+		resource:  res,
+		createdAt: receivedAt,
+		expiresAt: receivedAt.Add(goodbyeTTL),
 	})
 }
 
@@ -131,9 +142,9 @@ func (c *cache) applyCacheFlush(key cacheKey, receivedAt time.Time) {
 }
 
 // insertOrUpdate adds a new record or updates the TTL of an existing
-// record with the same rdata.
+// record with the same rdata. TTLs are clamped to maxRecordTTL.
 func (c *cache) insertOrUpdate(key cacheKey, res dnsmessage.Resource, receivedAt time.Time) {
-	ttl := time.Duration(res.Header.TTL) * time.Second
+	ttl := min(time.Duration(res.Header.TTL)*time.Second, maxRecordTTL)
 	entries := c.entries[key]
 
 	for idx := range entries {
@@ -142,18 +153,63 @@ func (c *cache) insertOrUpdate(key cacheKey, res dnsmessage.Resource, receivedAt
 			entries[idx].createdAt = receivedAt
 			entries[idx].expiresAt = receivedAt.Add(ttl)
 			entries[idx].originalTTL = ttl
+			entries[idx].refreshJitter = newRefreshJitter()
 			entries[idx].refreshesSent = 0
 
 			return
 		}
 	}
 
-	c.entries[key] = append(entries, cacheEntry{
-		resource:    res,
-		createdAt:   receivedAt,
-		expiresAt:   receivedAt.Add(ttl),
-		originalTTL: ttl,
+	c.appendEntry(key, cacheEntry{
+		resource:      res,
+		createdAt:     receivedAt,
+		expiresAt:     receivedAt.Add(ttl),
+		originalTTL:   ttl,
+		refreshJitter: newRefreshJitter(),
 	})
+}
+
+// appendEntry adds a new entry under key, evicting the entry closest to
+// expiry when the cache is at capacity.
+func (c *cache) appendEntry(key cacheKey, entry cacheEntry) {
+	if c.size >= maxCacheEntries {
+		c.evictSoonestExpiring()
+	}
+
+	c.entries[key] = append(c.entries[key], entry)
+	c.size++
+}
+
+// evictSoonestExpiring removes the entry with the earliest expiry.
+func (c *cache) evictSoonestExpiring() {
+	var victimKey cacheKey
+	victimIdx := -1
+	var victimExpiry time.Time
+
+	for key, entries := range c.entries {
+		for idx := range entries {
+			if victimIdx == -1 || entries[idx].expiresAt.Before(victimExpiry) {
+				victimKey = key
+				victimIdx = idx
+				victimExpiry = entries[idx].expiresAt
+			}
+		}
+	}
+
+	if victimIdx == -1 {
+		return
+	}
+
+	entries := c.entries[victimKey]
+	entries = append(entries[:victimIdx], entries[victimIdx+1:]...)
+
+	if len(entries) == 0 {
+		delete(c.entries, victimKey)
+	} else {
+		c.entries[victimKey] = entries
+	}
+
+	c.size--
 }
 
 // lookup returns non-expired records matching the name, type, and class.
@@ -192,6 +248,7 @@ func (c *cache) sweep() {
 	defer c.mu.Unlock()
 
 	now := c.now()
+	size := 0
 
 	for key, entries := range c.entries {
 		var alive []cacheEntry
@@ -206,8 +263,11 @@ func (c *cache) sweep() {
 			delete(c.entries, key)
 		} else {
 			c.entries[key] = alive
+			size += len(alive)
 		}
 	}
+
+	c.size = size
 }
 
 // refreshThresholds returns the fractions of TTL at which refresh queries
@@ -219,30 +279,38 @@ func refreshThresholds() [4]float64 {
 // maxRefreshJitter is the maximum random jitter added to each threshold.
 const maxRefreshJitter = 0.02
 
-// refreshCandidate identifies a cache entry that needs a refresh query.
-type refreshCandidate struct {
-	name    string
-	rrType  dnsmessage.Type
-	rrClass dnsmessage.Class
+// newRefreshJitter returns a random 0-2% addition to the next refresh
+// threshold (RFC 6762 §5.2). Rolled once per threshold so that repeated
+// polling does not bias refreshes toward the unjittered threshold.
+func newRefreshJitter() float64 {
+	return rand.Float64() * maxRefreshJitter //nolint:gosec // weak random is fine for jitter
 }
 
-// dueForRefresh checks the given cache keys and returns entries that have
-// reached their next refresh threshold. For each returned candidate,
-// refreshesSent is incremented. Only entries with originalTTL > 0 and
-// fewer than 4 refreshes sent are considered.
-func (c *cache) dueForRefresh(keys []cacheKey) []refreshCandidate {
+// dueForRefresh checks the given cache keys and returns those with entries
+// that have reached their next refresh threshold (RFC 6762 §5.2).
+// Duplicate keys are checked once. For each returned candidate,
+// refreshesSent is incremented; entries with originalTTL = 0 (goodbyes)
+// are skipped and at most four refreshes are sent per entry per TTL.
+func (c *cache) dueForRefresh(keys []cacheKey) []cacheKey {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	now := c.now()
-	var candidates []refreshCandidate
+	thresholds := refreshThresholds()
+
+	var candidates []cacheKey
+	seen := make(map[cacheKey]struct{}, len(keys))
 
 	for _, key := range keys {
-		entries := c.entries[key]
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
 
+		entries := c.entries[key]
 		for idx := range entries {
 			entry := &entries[idx]
-			if entry.originalTTL <= 0 || entry.refreshesSent >= 4 {
+			if entry.originalTTL <= 0 || int(entry.refreshesSent) >= len(thresholds) {
 				continue
 			}
 
@@ -251,15 +319,12 @@ func (c *cache) dueForRefresh(keys []cacheKey) []refreshCandidate {
 			}
 
 			startedAt := entry.expiresAt.Add(-entry.originalTTL)
-			elapsed := now.Sub(startedAt)
-			fraction := float64(elapsed) / float64(entry.originalTTL)
+			fraction := float64(now.Sub(startedAt)) / float64(entry.originalTTL)
 
-			//nolint:gosec // weak random is fine for jitter
-			threshold := refreshThresholds()[entry.refreshesSent] + rand.Float64()*maxRefreshJitter
-
-			if fraction >= threshold {
-				candidates = append(candidates, refreshCandidate(key))
+			if fraction >= thresholds[entry.refreshesSent]+entry.refreshJitter {
+				candidates = append(candidates, key)
 				entry.refreshesSent++
+				entry.refreshJitter = newRefreshJitter()
 			}
 		}
 	}
@@ -273,6 +338,7 @@ func (c *cache) flushAll() {
 	defer c.mu.Unlock()
 
 	c.entries = make(map[cacheKey][]cacheEntry)
+	c.size = 0
 }
 
 // reduceTTLs caps the remaining TTL of every entry to maxRemaining.

--- a/cache_test.go
+++ b/cache_test.go
@@ -695,7 +695,7 @@ func TestCacheConcurrency(t *testing.T) {
 
 		go func() {
 			defer wg.Done()
-			ca.dueForRefresh([]cacheKey{key})
+			ca.takeRefreshCandidates([]cacheKey{key})
 		}()
 	}
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -4,6 +4,7 @@
 package mdns
 
 import (
+	"fmt"
 	"net/netip"
 	"sync"
 	"testing"
@@ -666,10 +667,16 @@ func TestCacheConcurrency(t *testing.T) {
 	ca := newCache(clock.now)
 	rec := mustBuildA(t, "host.local.", "192.168.1.1", 120)
 
+	key := cacheKey{
+		name:    "host.local.",
+		rrType:  dnsmessage.TypeA,
+		rrClass: dnsmessage.ClassINET,
+	}
+
 	var wg sync.WaitGroup
 
 	for range 100 {
-		wg.Add(3)
+		wg.Add(4)
 
 		go func() {
 			defer wg.Done()
@@ -684,6 +691,11 @@ func TestCacheConcurrency(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			ca.sweep()
+		}()
+
+		go func() {
+			defer wg.Done()
+			ca.dueForRefresh([]cacheKey{key})
 		}()
 	}
 
@@ -763,4 +775,63 @@ func TestResourceDataEqualDifferentNames(t *testing.T) {
 	recB := mustBuildA(t, "b.local.", "192.168.1.1", 120)
 
 	assert.False(t, resourceDataEqual(recA, recB))
+}
+
+// ---------------------------------------------------------------------------
+// TTL clamping and capacity
+// ---------------------------------------------------------------------------
+
+func TestCacheTTLClampedToMax(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+
+	// A 24h TTL is clamped to maxRecordTTL (75 minutes).
+	ca.insert(mustBuildA(t, "host.local.", "10.0.0.1", 86400), clock.now())
+
+	results := ca.lookup("host.local.", dnsmessage.TypeA, dnsmessage.ClassINET)
+	require.Len(t, results, 1)
+	assert.LessOrEqual(t, time.Duration(results[0].Header.TTL)*time.Second, maxRecordTTL)
+
+	// Expired at the clamp boundary despite the huge advertised TTL.
+	clock.advance(maxRecordTTL + time.Second)
+	assert.Empty(t, ca.lookup("host.local.", dnsmessage.TypeA, dnsmessage.ClassINET))
+}
+
+func TestCacheCapEvictsSoonestExpiring(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+
+	// Short-lived record that should be evicted when the cache fills up.
+	ca.insert(mustBuildA(t, "victim.local.", "10.0.0.1", 5), clock.now())
+
+	for i := range maxCacheEntries {
+		name := fmt.Sprintf("host%d.local.", i)
+		ca.insert(mustBuildA(t, name, "10.0.0.2", 100), clock.now())
+	}
+
+	assert.Equal(t, maxCacheEntries, ca.len())
+	assert.Empty(t, ca.lookup("victim.local.", dnsmessage.TypeA, dnsmessage.ClassINET))
+}
+
+func TestCacheCapEvictionKeepsSiblingEntries(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+
+	// Two records under the same key (same name/type, different rdata);
+	// the shorter-lived one is the eviction victim.
+	ca.insert(mustBuildA(t, "shared.local.", "10.0.0.1", 5), clock.now())
+	ca.insert(mustBuildA(t, "shared.local.", "10.0.0.2", 100), clock.now())
+
+	for i := range maxCacheEntries - 1 {
+		name := fmt.Sprintf("host%d.local.", i)
+		ca.insert(mustBuildA(t, name, "10.0.0.3", 100), clock.now())
+	}
+
+	// The sibling under the shared key must survive the eviction.
+	results := ca.lookup("shared.local.", dnsmessage.TypeA, dnsmessage.ClassINET)
+	require.Len(t, results, 1)
+
+	body, ok := results[0].Body.(*dnsmessage.AResource)
+	require.True(t, ok)
+	assert.Equal(t, [4]byte{10, 0, 0, 2}, body.A)
 }

--- a/client.go
+++ b/client.go
@@ -59,11 +59,12 @@ func newClient(
 	name string,
 	writer questionWriter,
 	hasIPv4, hasIPv6 bool,
+	recordCache *cache,
 ) *client {
 	return &client{
 		log:     log,
 		name:    name,
-		handler: newAnswerHandler(log, name),
+		handler: newAnswerHandler(log, name, recordCache),
 		writer:  writer,
 		hasIPv4: hasIPv4,
 		hasIPv6: hasIPv6,
@@ -198,13 +199,15 @@ type answerHandler struct {
 	enumerateSessions []*enumerateSession
 	log               logging.LeveledLogger
 	name              string
+	cache             *cache
 }
 
 // newAnswerHandler creates a new answerHandler.
-func newAnswerHandler(log logging.LeveledLogger, name string) *answerHandler {
+func newAnswerHandler(log logging.LeveledLogger, name string, recordCache *cache) *answerHandler {
 	return &answerHandler{
-		log:  log,
-		name: name,
+		log:   log,
+		name:  name,
+		cache: recordCache,
 	}
 }
 
@@ -269,6 +272,29 @@ func (h *answerHandler) unregisterEnumerateSession(session *enumerateSession) {
 	}
 }
 
+// monitoredCacheKeys returns cache keys for all actively-monitored records
+// across browse and enumerate sessions.
+func (h *answerHandler) monitoredCacheKeys() []cacheKey {
+	h.mu.RLock()
+	browseSessions := make([]*browseSession, len(h.browseSessions))
+	copy(browseSessions, h.browseSessions)
+	enumerateSessions := make([]*enumerateSession, len(h.enumerateSessions))
+	copy(enumerateSessions, h.enumerateSessions)
+	h.mu.RUnlock()
+
+	var keys []cacheKey
+
+	for _, session := range browseSessions {
+		keys = append(keys, session.monitoredCacheKeys()...)
+	}
+
+	for _, session := range enumerateSessions {
+		keys = append(keys, session.monitoredCacheKeys()...)
+	}
+
+	return keys
+}
+
 // handle processes a DNS message containing answers.
 // It matches answers against registered name queries, active browse sessions,
 // and active enumerate sessions.
@@ -288,6 +314,11 @@ func (h *answerHandler) handle(ctx *messageContext, msg *dnsmessage.Message) {
 	allRecords := make([]dnsmessage.Resource, 0, len(msg.Answers)+len(msg.Additionals))
 	allRecords = append(allRecords, msg.Answers...)
 	allRecords = append(allRecords, msg.Additionals...)
+
+	// Insert all received records into the cache.
+	for _, record := range allRecords {
+		h.cache.insert(record, ctx.timestamp)
+	}
 
 	for _, answer := range allRecords {
 		// Match against browse sessions (all record types).
@@ -425,6 +456,54 @@ func newBrowseSession(ctx context.Context, serviceType string, emit func(Service
 // serviceName returns the fully-qualified browse query name.
 func (bs *browseSession) serviceName() string {
 	return bs.serviceType + "." + bs.domain + "."
+}
+
+// monitoredCacheKeys returns cache keys for records this browse session
+// is actively monitoring: the PTR for the service type, plus SRV/TXT/A/AAAA
+// keys for known instances.
+func (bs *browseSession) monitoredCacheKeys() []cacheKey {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+
+	svcName := strings.ToLower(bs.serviceType + "." + bs.domain + ".")
+
+	keys := []cacheKey{
+		{name: svcName, rrType: dnsmessage.TypePTR, rrClass: dnsmessage.ClassINET},
+	}
+
+	// Add keys for pending instances.
+	for _, inst := range bs.pending {
+		keys = append(keys, bs.instanceCacheKeys(inst)...)
+	}
+
+	// Add keys for already-seen instances (they remain in the seen map).
+	// We don't track full details for emitted instances, but the PTR key
+	// above covers rediscovery.
+
+	return keys
+}
+
+// instanceCacheKeys returns cache keys for a pending service instance.
+func (bs *browseSession) instanceCacheKeys(inst *pendingInstance) []cacheKey {
+	var keys []cacheKey
+
+	instanceName := strings.ToLower(
+		escapeInstanceName(inst.instance) + "." + inst.service + "." + inst.domain + ".",
+	)
+	keys = append(keys,
+		cacheKey{name: instanceName, rrType: dnsmessage.TypeSRV, rrClass: dnsmessage.ClassINET},
+		cacheKey{name: instanceName, rrType: dnsmessage.TypeTXT, rrClass: dnsmessage.ClassINET},
+	)
+
+	if inst.host != "" {
+		hostName := strings.ToLower(inst.host)
+		keys = append(keys,
+			cacheKey{name: hostName, rrType: dnsmessage.TypeA, rrClass: dnsmessage.ClassINET},
+			cacheKey{name: hostName, rrType: dnsmessage.TypeAAAA, rrClass: dnsmessage.ClassINET},
+		)
+	}
+
+	return keys
 }
 
 // processRecord updates the browse session with a received DNS resource record.
@@ -612,6 +691,16 @@ func newEnumerateSession(ctx context.Context, emit func(string)) *enumerateSessi
 	}
 }
 
+// monitoredCacheKeys returns the cache key for the service type enumeration
+// meta-query PTR record.
+func (es *enumerateSession) monitoredCacheKeys() []cacheKey {
+	name := strings.ToLower(serviceTypeEnumerationName + "." + es.domain + ".")
+
+	return []cacheKey{
+		{name: name, rrType: dnsmessage.TypePTR, rrClass: dnsmessage.ClassINET},
+	}
+}
+
 // processRecord handles a PTR answer for the service type enumeration meta-query.
 func (es *enumerateSession) processRecord(answer dnsmessage.Resource) {
 	if answer.Header.Type != dnsmessage.TypePTR {
@@ -640,6 +729,37 @@ func (es *enumerateSession) processRecord(answer dnsmessage.Resource) {
 	es.seen[serviceType] = true
 
 	es.emit(serviceType)
+}
+
+// sendRefreshQuestion sends a multicast DNS question for the given name and type.
+// Used to refresh actively-monitored cache entries per RFC 6762 §5.2.
+func (c *client) sendRefreshQuestion(name string, rrType dnsmessage.Type) {
+	packedName, err := dnsmessage.NewName(name)
+	if err != nil {
+		c.log.Warnf("[%s] failed to construct refresh query name %v", c.name, err)
+
+		return
+	}
+
+	msg := dnsmessage.Message{
+		Header: dnsmessage.Header{},
+		Questions: []dnsmessage.Question{
+			{
+				Type:  rrType,
+				Class: dnsmessage.ClassINET,
+				Name:  packedName,
+			},
+		},
+	}
+
+	rawQuery, err := msg.Pack()
+	if err != nil {
+		c.log.Warnf("[%s] failed to pack refresh query %v", c.name, err)
+
+		return
+	}
+
+	c.writer.writeQuestion(rawQuery)
 }
 
 func addrFromAnswer(answer dnsmessage.Resource) (*netip.Addr, error) {

--- a/client.go
+++ b/client.go
@@ -731,35 +731,44 @@ func (es *enumerateSession) processRecord(answer dnsmessage.Resource) {
 	es.emit(serviceType)
 }
 
-// sendRefreshQuestion sends a multicast DNS question for the given name and type.
-// Used to refresh actively-monitored cache entries per RFC 6762 §5.2.
-func (c *client) sendRefreshQuestion(name string, rrType dnsmessage.Type) {
-	packedName, err := dnsmessage.NewName(name)
-	if err != nil {
-		c.log.Warnf("[%s] failed to construct refresh query name %v", c.name, err)
+// maxRefreshQuestionsPerMessage caps how many questions are packed into a
+// single refresh query message to stay well under the mDNS packet limit.
+const maxRefreshQuestionsPerMessage = 10
 
-		return
+// sendRefreshQuestions sends multicast DNS questions for the given cache
+// keys, batching multiple questions per message (RFC 6762 §7.2). Used to
+// refresh actively-monitored cache entries per RFC 6762 §5.2.
+func (c *client) sendRefreshQuestions(keys []cacheKey) {
+	questions := make([]dnsmessage.Question, 0, len(keys))
+
+	for _, key := range keys {
+		packedName, err := dnsmessage.NewName(key.name)
+		if err != nil {
+			c.log.Warnf("[%s] failed to construct refresh query name %v", c.name, err)
+
+			continue
+		}
+
+		questions = append(questions, dnsmessage.Question{
+			Type:  key.rrType,
+			Class: dnsmessage.ClassINET,
+			Name:  packedName,
+		})
 	}
 
-	msg := dnsmessage.Message{
-		Header: dnsmessage.Header{},
-		Questions: []dnsmessage.Question{
-			{
-				Type:  rrType,
-				Class: dnsmessage.ClassINET,
-				Name:  packedName,
-			},
-		},
+	for start := 0; start < len(questions); start += maxRefreshQuestionsPerMessage {
+		end := min(start+maxRefreshQuestionsPerMessage, len(questions))
+		msg := dnsmessage.Message{Questions: questions[start:end]}
+
+		rawQuery, err := msg.Pack()
+		if err != nil {
+			c.log.Warnf("[%s] failed to pack refresh query %v", c.name, err)
+
+			continue
+		}
+
+		c.writer.writeQuestion(rawQuery)
 	}
-
-	rawQuery, err := msg.Pack()
-	if err != nil {
-		c.log.Warnf("[%s] failed to pack refresh query %v", c.name, err)
-
-		return
-	}
-
-	c.writer.writeQuestion(rawQuery)
 }
 
 func addrFromAnswer(answer dnsmessage.Resource) (*netip.Addr, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestAnswerHandlerRegisterUnregister(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	// Register a query
 	resultChan := make(chan queryResult, 1)
@@ -51,7 +51,7 @@ func TestAnswerHandlerRegisterUnregister(t *testing.T) {
 
 func TestAnswerHandlerHandleMatchingAnswer(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	resultChan := make(chan queryResult, 1)
 	handler.registerQuery("test.local.", resultChan)
@@ -93,7 +93,7 @@ func TestAnswerHandlerHandleMatchingAnswer(t *testing.T) {
 
 func TestAnswerHandlerHandleMatchingAnswerIPv6(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	resultChan := make(chan queryResult, 1)
 	handler.registerQuery("test.local.", resultChan)
@@ -134,7 +134,7 @@ func TestAnswerHandlerHandleMatchingAnswerIPv6(t *testing.T) {
 
 func TestAnswerHandlerHandleNonMatchingName(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	resultChan := make(chan queryResult, 1)
 	handler.registerQuery("test.local.", resultChan)
@@ -175,7 +175,7 @@ func TestAnswerHandlerHandleNonMatchingName(t *testing.T) {
 
 func TestAnswerHandlerHandleCaseInsensitive(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	resultChan := make(chan queryResult, 1)
 	handler.registerQuery("TEST.LOCAL.", resultChan)
@@ -213,7 +213,7 @@ func TestAnswerHandlerHandleCaseInsensitive(t *testing.T) {
 
 func TestAnswerHandlerHandleSkipsNonAddressTypes(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	resultChan := make(chan queryResult, 1)
 	handler.registerQuery("test.local.", resultChan)
@@ -255,7 +255,7 @@ func TestAnswerHandlerHandleSkipsNonAddressTypes(t *testing.T) {
 
 func TestAnswerHandlerHandleMultipleAnswers(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	resultChan1 := make(chan queryResult, 1)
 	resultChan2 := make(chan queryResult, 1)
@@ -314,7 +314,7 @@ func TestAnswerHandlerHandleMultipleAnswers(t *testing.T) {
 
 func TestAnswerHandlerHandleSkipsMalformedAnswer(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	resultChan := make(chan queryResult, 1)
 	handler.registerQuery("test.local.", resultChan)
@@ -365,7 +365,7 @@ func TestAnswerHandlerHandleSkipsMalformedAnswer(t *testing.T) {
 
 func TestAnswerHandlerHandleChannelFull(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	// Create unbuffered channel that's already "full" (no receiver)
 	resultChan := make(chan queryResult)
@@ -469,7 +469,7 @@ func buildBrowseResponseMsg(t *testing.T) *dnsmessage.Message {
 
 func TestBrowseSessionSinglePacketResolution(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	var mu sync.Mutex
 	var events []ServiceEvent
@@ -514,7 +514,7 @@ func TestBrowseSessionSinglePacketResolution(t *testing.T) {
 
 func TestBrowseSessionDeduplication(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	var mu sync.Mutex
 	var callCount int
@@ -549,7 +549,7 @@ func TestBrowseSessionDeduplication(t *testing.T) {
 
 func TestBrowseSessionMultipleInstances(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	var mu sync.Mutex
 	seen := make(map[string]bool)
@@ -622,7 +622,7 @@ func TestBrowseSessionMultipleInstances(t *testing.T) {
 
 func TestBrowseSessionMultiPacketResolution(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	var mu sync.Mutex
 	var events []ServiceEvent
@@ -714,7 +714,7 @@ func TestBrowseSessionMultiPacketResolution(t *testing.T) {
 
 func TestEnumerateSession(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	var mu sync.Mutex
 	var discovered []string
@@ -771,7 +771,7 @@ func TestEnumerateSession(t *testing.T) {
 
 func TestEnumerateSessionDeduplication(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	var mu sync.Mutex
 	var callCount int
@@ -817,7 +817,7 @@ func TestEnumerateSessionDeduplication(t *testing.T) {
 
 func TestBrowseSessionRegisterUnregister(t *testing.T) {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	ctx := t.Context()
 
@@ -836,7 +836,7 @@ func TestBrowseSessionRegisterUnregister(t *testing.T) {
 func TestAnswerHandlerExistingBehaviorUnchanged(t *testing.T) {
 	// Verify that existing name query behavior is not broken by browse additions.
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	handler := newAnswerHandler(log, "test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
 
 	resultChan := make(chan queryResult, 1)
 	handler.registerQuery("test.local.", resultChan)
@@ -876,4 +876,188 @@ func TestAnswerHandlerExistingBehaviorUnchanged(t *testing.T) {
 	}
 
 	assert.Empty(t, handler.queries)
+}
+
+// ---------------------------------------------------------------------------
+// Cache insertion via answerHandler
+// ---------------------------------------------------------------------------
+
+func TestAnswerHandlerCachesRecords(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	handler := newAnswerHandler(log, "test", ca)
+
+	msgCtx := &messageContext{
+		source:    &net.UDPAddr{IP: net.IPv4(192, 168, 1, 1), Port: 5353},
+		ifIndex:   1,
+		timestamp: clock.now(),
+	}
+
+	msg := buildBrowseResponseMsg(t)
+	handler.handle(msgCtx, msg)
+
+	// PTR from Answers.
+	results := ca.lookup("_http._tcp.local.", dnsmessage.TypePTR, dnsmessage.ClassINET)
+	assert.Len(t, results, 1)
+
+	// SRV from Additionals.
+	results = ca.lookup("My Web._http._tcp.local.", dnsmessage.TypeSRV, dnsmessage.ClassINET)
+	assert.Len(t, results, 1)
+
+	// TXT from Additionals.
+	results = ca.lookup("My Web._http._tcp.local.", dnsmessage.TypeTXT, dnsmessage.ClassINET)
+	assert.Len(t, results, 1)
+
+	// A from Additionals.
+	results = ca.lookup("myhost.local.", dnsmessage.TypeA, dnsmessage.ClassINET)
+	assert.Len(t, results, 1)
+}
+
+func TestAnswerHandlerCacheGoodbye(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	handler := newAnswerHandler(log, "test", ca)
+
+	msgCtx := &messageContext{
+		source:    &net.UDPAddr{IP: net.IPv4(192, 168, 1, 1), Port: 5353},
+		ifIndex:   1,
+		timestamp: clock.now(),
+	}
+
+	// Insert a record first.
+	msg := &dnsmessage.Message{
+		Answers: []dnsmessage.Resource{
+			{
+				Header: dnsmessage.ResourceHeader{
+					Name: dnsmessage.MustNewName("host.local."),
+					Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: 120,
+				},
+				Body: &dnsmessage.AResource{A: [4]byte{10, 0, 0, 1}},
+			},
+		},
+	}
+	handler.handle(msgCtx, msg)
+
+	// Send goodbye (TTL=0).
+	goodbyeMsg := &dnsmessage.Message{
+		Answers: []dnsmessage.Resource{
+			{
+				Header: dnsmessage.ResourceHeader{
+					Name: dnsmessage.MustNewName("host.local."),
+					Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: 0,
+				},
+				Body: &dnsmessage.AResource{A: [4]byte{10, 0, 0, 1}},
+			},
+		},
+	}
+	handler.handle(msgCtx, goodbyeMsg)
+
+	// Still visible (retained for 1s).
+	results := ca.lookup("host.local.", dnsmessage.TypeA, dnsmessage.ClassINET)
+	assert.Len(t, results, 1)
+
+	// After 2s, gone.
+	clock.advance(2 * time.Second)
+	results = ca.lookup("host.local.", dnsmessage.TypeA, dnsmessage.ClassINET)
+	assert.Empty(t, results)
+}
+
+func TestAnswerHandlerCacheFlushBit(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	handler := newAnswerHandler(log, "test", ca)
+
+	msgCtx := &messageContext{
+		source:    &net.UDPAddr{IP: net.IPv4(192, 168, 1, 1), Port: 5353},
+		ifIndex:   1,
+		timestamp: clock.now(),
+	}
+
+	// Insert old record.
+	msg := &dnsmessage.Message{
+		Answers: []dnsmessage.Resource{
+			{
+				Header: dnsmessage.ResourceHeader{
+					Name: dnsmessage.MustNewName("host.local."),
+					Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: 300,
+				},
+				Body: &dnsmessage.AResource{A: [4]byte{10, 0, 0, 1}},
+			},
+		},
+	}
+	handler.handle(msgCtx, msg)
+
+	// Advance past cache-flush delay.
+	clock.advance(2 * time.Second)
+	msgCtx.timestamp = clock.now()
+
+	// Insert new record with cache-flush bit.
+	flushMsg := &dnsmessage.Message{
+		Answers: []dnsmessage.Resource{
+			{
+				Header: dnsmessage.ResourceHeader{
+					Name: dnsmessage.MustNewName("host.local."),
+					Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET | rrClassCacheFlush, TTL: 120,
+				},
+				Body: &dnsmessage.AResource{A: [4]byte{10, 0, 0, 2}},
+			},
+		},
+	}
+	handler.handle(msgCtx, flushMsg)
+
+	// Advance past flush delay.
+	clock.advance(2 * time.Second)
+
+	results := ca.lookup("host.local.", dnsmessage.TypeA, dnsmessage.ClassINET)
+	require.Len(t, results, 1)
+
+	body, ok := results[0].Body.(*dnsmessage.AResource)
+	require.True(t, ok)
+	assert.Equal(t, [4]byte{10, 0, 0, 2}, body.A)
+}
+
+// ---------------------------------------------------------------------------
+// Monitored cache keys
+// ---------------------------------------------------------------------------
+
+func TestBrowseSessionMonitoredKeys(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	session := newBrowseSession(ctx, "_http._tcp", func(ServiceEvent) {})
+
+	keys := session.monitoredCacheKeys()
+	require.Len(t, keys, 1)
+	assert.Equal(t, "_http._tcp.local.", keys[0].name)
+	assert.Equal(t, dnsmessage.TypePTR, keys[0].rrType)
+
+	// Add a pending instance.
+	session.mu.Lock()
+	session.pending["My Web"] = &pendingInstance{
+		instance: "My Web",
+		service:  "_http._tcp",
+		domain:   "local",
+		host:     "myhost.local.",
+		hasSRV:   true,
+	}
+	session.mu.Unlock()
+
+	keys = session.monitoredCacheKeys()
+	// PTR + SRV + TXT + A + AAAA = 5.
+	assert.Len(t, keys, 5)
+}
+
+func TestEnumerateSessionMonitoredKeys(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	session := newEnumerateSession(ctx, func(string) {})
+	keys := session.monitoredCacheKeys()
+
+	require.Len(t, keys, 1)
+	assert.Equal(t, "_services._dns-sd._udp.local.", keys[0].name)
+	assert.Equal(t, dnsmessage.TypePTR, keys[0].rrType)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1024,10 +1024,7 @@ func TestAnswerHandlerCacheFlushBit(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestBrowseSessionMonitoredKeys(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	session := newBrowseSession(ctx, "_http._tcp", func(ServiceEvent) {})
+	session := newBrowseSession(t.Context(), "_http._tcp", func(ServiceEvent) {})
 
 	keys := session.monitoredCacheKeys()
 	require.Len(t, keys, 1)
@@ -1051,10 +1048,7 @@ func TestBrowseSessionMonitoredKeys(t *testing.T) {
 }
 
 func TestEnumerateSessionMonitoredKeys(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	session := newEnumerateSession(ctx, func(string) {})
+	session := newEnumerateSession(t.Context(), func(string) {})
 	keys := session.monitoredCacheKeys()
 
 	require.Len(t, keys, 1)

--- a/config.go
+++ b/config.go
@@ -12,7 +12,10 @@ import (
 	"golang.org/x/net/dns/dnsmessage"
 )
 
-var errResponseTTLZero = errors.New("response TTL must be greater than 0")
+var (
+	errResponseTTLZero            = errors.New("response TTL must be greater than 0")
+	errRefreshIntervalNonPositive = errors.New("refresh interval must be greater than 0")
+)
 
 const (
 	// DefaultAddressIPv4 is the default used by mDNS
@@ -296,13 +299,17 @@ func (o cacheRefreshOption) applyServer(c *serverConfig) error {
 type refreshIntervalOption time.Duration
 
 // WithRefreshInterval sets how often the cache refresh loop checks for
-// records due for refresh. Default is 2 seconds. Only effective when
-// cache refresh is enabled.
+// records due for refresh. Default is 2 seconds. Must be greater than
+// zero. Only effective when cache refresh is enabled.
 func WithRefreshInterval(interval time.Duration) refreshIntervalOption {
 	return refreshIntervalOption(interval)
 }
 
 func (o refreshIntervalOption) applyServer(c *serverConfig) error {
+	if o <= 0 {
+		return errRefreshIntervalNonPositive
+	}
+
 	c.refreshCheckInterval = time.Duration(o)
 
 	return nil

--- a/config.go
+++ b/config.go
@@ -274,3 +274,36 @@ func (o responseTTLOption) applyServer(c *serverConfig) error {
 
 	return nil
 }
+
+// cacheRefreshOption enables or disables proactive cache refresh.
+type cacheRefreshOption bool
+
+// WithCacheRefresh enables or disables proactive cache refresh per RFC 6762 §5.2.
+// When enabled, actively-monitored records are re-queried at 80/85/90/95%
+// of their TTL. Enabled by default in NewServer; disabled in the legacy
+// Server constructor.
+func WithCacheRefresh(enable bool) cacheRefreshOption {
+	return cacheRefreshOption(enable)
+}
+
+func (o cacheRefreshOption) applyServer(c *serverConfig) error {
+	c.cacheRefresh = bool(o)
+
+	return nil
+}
+
+// refreshIntervalOption sets the refresh check interval.
+type refreshIntervalOption time.Duration
+
+// WithRefreshInterval sets how often the cache refresh loop checks for
+// records due for refresh. Default is 2 seconds. Only effective when
+// cache refresh is enabled.
+func WithRefreshInterval(interval time.Duration) refreshIntervalOption {
+	return refreshIntervalOption(interval)
+}
+
+func (o refreshIntervalOption) applyServer(c *serverConfig) error {
+	c.refreshCheckInterval = time.Duration(o)
+
+	return nil
+}

--- a/conn.go
+++ b/conn.go
@@ -40,6 +40,18 @@ type Conn struct {
 	// server handles response operations
 	server *server
 
+	// cache stores received DNS records with TTL management.
+	cache *cache
+
+	// stopBackground signals background goroutines (sweep, refresh) to stop.
+	stopBackground chan struct{}
+
+	// cacheRefresh enables proactive cache refresh per RFC 6762 §5.2.
+	cacheRefresh bool
+
+	// refreshCheckInterval overrides the default refresh polling interval.
+	refreshCheckInterval time.Duration
+
 	// onServiceDiscovered is the handler for Browse results.
 	onServiceDiscovered atomic.Value // func(ServiceEvent)
 
@@ -60,11 +72,13 @@ type queryResult struct {
 }
 
 const (
-	defaultQueryInterval = time.Second
-	destinationAddress4  = "224.0.0.251:5353"
-	destinationAddress6  = "[FF02::FB]:5353"
-	maxMessageRecords    = 3
-	responseTTL          = 120
+	defaultQueryInterval        = time.Second
+	defaultSweepInterval        = 10 * time.Second
+	defaultRefreshCheckInterval = 2 * time.Second
+	destinationAddress4         = "224.0.0.251:5353"
+	destinationAddress6         = "[FF02::FB]:5353"
+	maxMessageRecords           = 3
+	responseTTL                 = 120
 	// maxPacketSize is the maximum size of a mdns packet.
 	// From RFC 6762:
 	// Even when fragmentation is used, a Multicast DNS packet, including IP
@@ -570,6 +584,8 @@ func (c *Conn) start(started chan<- struct{}, inboundBufferSize int, config *ser
 		close(c.closed)
 	}()
 
+	backgroundWG := c.startBackgroundLoops()
+
 	var numReaders int
 	readerStarted := make(chan struct{})
 	readerEnded := make(chan struct{})
@@ -620,6 +636,83 @@ func (c *Conn) start(started chan<- struct{}, inboundBufferSize int, config *ser
 	close(started)
 	for i := 0; i < numReaders; i++ {
 		<-readerEnded
+	}
+
+	// All readers done — stop background goroutines.
+	if c.stopBackground != nil {
+		close(c.stopBackground)
+	}
+
+	backgroundWG.Wait()
+}
+
+// startBackgroundLoops launches the sweep and optional refresh goroutines.
+// Returns a WaitGroup that completes when all background goroutines exit.
+func (c *Conn) startBackgroundLoops() *sync.WaitGroup {
+	var backgroundWG sync.WaitGroup
+
+	if c.cache == nil || c.stopBackground == nil {
+		return &backgroundWG
+	}
+
+	backgroundWG.Add(1)
+
+	go func() {
+		defer backgroundWG.Done()
+		c.sweepLoop()
+	}()
+
+	if c.cacheRefresh {
+		backgroundWG.Add(1)
+
+		go func() {
+			defer backgroundWG.Done()
+			c.refreshLoop()
+		}()
+	}
+
+	return &backgroundWG
+}
+
+// sweepLoop periodically removes expired cache entries.
+func (c *Conn) sweepLoop() {
+	ticker := time.NewTicker(defaultSweepInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			c.cache.sweep()
+		case <-c.stopBackground:
+			return
+		}
+	}
+}
+
+// refreshLoop periodically checks monitored cache entries for refresh.
+// Per RFC 6762 §5.2, actively-monitored records are refreshed at
+// 80/85/90/95% of their TTL.
+func (c *Conn) refreshLoop() {
+	interval := c.refreshCheckInterval
+	if interval == 0 {
+		interval = defaultRefreshCheckInterval
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			keys := c.client.handler.monitoredCacheKeys()
+			candidates := c.cache.dueForRefresh(keys)
+
+			for idx := range candidates {
+				c.client.sendRefreshQuestion(candidates[idx].name, candidates[idx].rrType)
+			}
+		case <-c.stopBackground:
+			return
+		}
 	}
 }
 

--- a/conn.go
+++ b/conn.go
@@ -77,7 +77,7 @@ const (
 	defaultRefreshCheckInterval = 2 * time.Second
 	destinationAddress4         = "224.0.0.251:5353"
 	destinationAddress6         = "[FF02::FB]:5353"
-	responseTTL = 120
+	responseTTL                 = 120
 	// maxPacketSize is the maximum size of a mdns packet.
 	// From RFC 6762:
 	// Even when fragmentation is used, a Multicast DNS packet, including IP

--- a/conn.go
+++ b/conn.go
@@ -712,7 +712,7 @@ func (c *Conn) refreshLoop() {
 		select {
 		case <-ticker.C:
 			keys := c.client.handler.monitoredCacheKeys()
-			if candidates := c.cache.dueForRefresh(keys); len(candidates) > 0 {
+			if candidates := c.cache.takeRefreshCandidates(keys); len(candidates) > 0 {
 				c.client.sendRefreshQuestions(candidates)
 			}
 		case <-c.stopBackground:

--- a/conn.go
+++ b/conn.go
@@ -77,8 +77,7 @@ const (
 	defaultRefreshCheckInterval = 2 * time.Second
 	destinationAddress4         = "224.0.0.251:5353"
 	destinationAddress6         = "[FF02::FB]:5353"
-	maxMessageRecords           = 3
-	responseTTL                 = 120
+	responseTTL = 120
 	// maxPacketSize is the maximum size of a mdns packet.
 	// From RFC 6762:
 	// Even when fragmentation is used, a Multicast DNS packet, including IP

--- a/conn.go
+++ b/conn.go
@@ -52,6 +52,9 @@ type Conn struct {
 	// refreshCheckInterval overrides the default refresh polling interval.
 	refreshCheckInterval time.Duration
 
+	// sweepInterval overrides the default cache sweep interval.
+	sweepInterval time.Duration
+
 	// onServiceDiscovered is the handler for Browse results.
 	onServiceDiscovered atomic.Value // func(ServiceEvent)
 
@@ -675,7 +678,12 @@ func (c *Conn) startBackgroundLoops() *sync.WaitGroup {
 
 // sweepLoop periodically removes expired cache entries.
 func (c *Conn) sweepLoop() {
-	ticker := time.NewTicker(defaultSweepInterval)
+	interval := c.sweepInterval
+	if interval == 0 {
+		interval = defaultSweepInterval
+	}
+
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
@@ -704,10 +712,8 @@ func (c *Conn) refreshLoop() {
 		select {
 		case <-ticker.C:
 			keys := c.client.handler.monitoredCacheKeys()
-			candidates := c.cache.dueForRefresh(keys)
-
-			for idx := range candidates {
-				c.client.sendRefreshQuestion(candidates[idx].name, candidates[idx].rrType)
+			if candidates := c.cache.dueForRefresh(keys); len(candidates) > 0 {
+				c.client.sendRefreshQuestions(candidates)
 			}
 		case <-c.stopBackground:
 			return

--- a/conn_test.go
+++ b/conn_test.go
@@ -1129,12 +1129,18 @@ func TestBrowseMultipleServicesEndToEnd(t *testing.T) {
 		mu.Lock()
 		defer mu.Unlock()
 		seen[evt.Instance.Instance] = evt.Instance.Port
-		if len(seen) == 2 {
-			select {
-			case <-done:
-			default:
-				close(done)
-			}
+		// Check for the specific instances: real mDNS traffic on the test
+		// machine's network may add unrelated entries.
+		if _, ok := seen["First Service"]; !ok {
+			return
+		}
+		if _, ok := seen["Second Service"]; !ok {
+			return
+		}
+		select {
+		case <-done:
+		default:
+			close(done)
 		}
 	})
 
@@ -1151,6 +1157,78 @@ func TestBrowseMultipleServicesEndToEnd(t *testing.T) {
 	assert.Equal(t, uint16(8080), seen["First Service"])
 	assert.Equal(t, uint16(9090), seen["Second Service"])
 	mu.Unlock()
+
+	cancel()
+	assert.NoError(t, aServer.Close())
+	assert.NoError(t, bServer.Close())
+}
+
+// TestBrowseCacheRefreshKeepsRecordAlive verifies the RFC 6762 §5.2 closed
+// loop: a browsed record with a short TTL is re-queried before expiry and
+// the answer keeps the cache entry alive past the original TTL.
+func TestBrowseCacheRefreshKeepsRecordAlive(t *testing.T) {
+	lim := test.TimeOut(time.Second * 30)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	aSock := createListener4(t)
+	bSock := createListener4(t)
+
+	darwinOpts := darwinMulticastOpts(t)
+
+	// Advertise with a 2s TTL so the refresh path triggers quickly.
+	aServer, err := NewServer(ipv4.NewPacketConn(aSock), nil,
+		append([]ServerOption{
+			WithLocalNames("myhost.local"),
+			WithResponseTTL(2),
+			WithService(ServiceInstance{
+				Instance: "Refresh Me",
+				Service:  "_http._tcp",
+				Port:     8080,
+			}),
+		}, darwinOpts...)...,
+	)
+	assert.NoError(t, err)
+
+	bServer, err := NewServer(ipv4.NewPacketConn(bSock), nil,
+		append([]ServerOption{
+			WithRefreshInterval(100 * time.Millisecond),
+		}, darwinOpts...)...,
+	)
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	discovered := make(chan struct{})
+	bServer.OnServiceDiscovered(func(evt ServiceEvent) {
+		if evt.Instance.Instance != "Refresh Me" {
+			return
+		}
+		select {
+		case <-discovered:
+		default:
+			close(discovered)
+		}
+	})
+
+	err = bServer.Browse(ctx, "_http._tcp")
+	assert.NoError(t, err)
+
+	select {
+	case <-discovered:
+	case <-ctx.Done():
+		assert.Fail(t, "timed out waiting for browse result")
+	}
+
+	// Wait past the original 2s TTL. Refresh queries at 80%+ of TTL must
+	// have re-fetched the record, keeping it alive in the cache.
+	time.Sleep(2500 * time.Millisecond)
+
+	results := bServer.cache.lookup("_http._tcp.local.", dnsmessage.TypePTR, dnsmessage.ClassINET)
+	assert.NotEmpty(t, results, "PTR record should be kept alive by cache refresh")
 
 	cancel()
 	assert.NoError(t, aServer.Close())
@@ -1242,12 +1320,15 @@ func TestEnumerateServiceTypesEndToEnd(t *testing.T) {
 		mu.Lock()
 		defer mu.Unlock()
 		seen[svcType] = true
-		if len(seen) == 2 {
-			select {
-			case <-done:
-			default:
-				close(done)
-			}
+		// Check for the specific types: real mDNS traffic on the test
+		// machine's network may add unrelated entries.
+		if !seen["_http._tcp"] || !seen["_ipp._tcp"] {
+			return
+		}
+		select {
+		case <-done:
+		default:
+			close(done)
 		}
 	})
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -750,12 +750,13 @@ func TestLocalNameCaseInsensitivity(t *testing.T) {
 		multicastPktConnV4: fp,
 		dstAddr4:           dstAddr4,
 		ifaces:             ifaces,
+		cache:              newCache(time.Now),
 		closed:             make(chan any),
 		localNames:         localNames,
 	}
 
 	// Create client and server
-	conn.client = newClient(log, "test", conn, true, false)
+	conn.client = newClient(log, "test", conn, true, false, conn.cache)
 	conn.server = newServer(
 		log,
 		"test",
@@ -834,11 +835,12 @@ func TestCommunicationCaseInsensitivity(t *testing.T) {
 		multicastPktConnV4: fp,
 		dstAddr4:           dstAddr4,
 		ifaces:             ifaces,
+		cache:              newCache(time.Now),
 		closed:             make(chan any),
 	}
 
 	// Create client (no server needed for this test)
-	conn.client = newClient(log, "test", conn, true, false)
+	conn.client = newClient(log, "test", conn, true, false, conn.cache)
 
 	started := make(chan struct{})
 	go conn.start(started, 1500, &serverConfig{})
@@ -1146,9 +1148,9 @@ func TestBrowseMultipleServicesEndToEnd(t *testing.T) {
 	}
 
 	mu.Lock()
-	defer mu.Unlock()
 	assert.Equal(t, uint16(8080), seen["First Service"])
 	assert.Equal(t, uint16(9090), seen["Second Service"])
+	mu.Unlock()
 
 	cancel()
 	assert.NoError(t, aServer.Close())
@@ -1259,9 +1261,9 @@ func TestEnumerateServiceTypesEndToEnd(t *testing.T) {
 	}
 
 	mu.Lock()
-	defer mu.Unlock()
 	assert.True(t, seen["_http._tcp"])
 	assert.True(t, seen["_ipp._tcp"])
+	mu.Unlock()
 
 	cancel()
 	assert.NoError(t, aServer.Close())

--- a/refresh_test.go
+++ b/refresh_test.go
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package mdns
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+func TestRefreshAt80Percent(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+
+	rec := mustBuildA(t, "host.local.", "192.168.1.1", 100)
+	ca.insert(rec, clock.now())
+
+	key := cacheKey{
+		name:    "host.local.",
+		rrType:  dnsmessage.TypeA,
+		rrClass: dnsmessage.ClassINET,
+	}
+
+	// At 79s — not yet due.
+	clock.advance(79 * time.Second)
+	candidates := ca.dueForRefresh([]cacheKey{key})
+	assert.Empty(t, candidates)
+
+	// At 82s — past 80% threshold (even with up to 2% jitter = 82%).
+	clock.advance(3 * time.Second)
+	candidates = ca.dueForRefresh([]cacheKey{key})
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "host.local.", candidates[0].name)
+	assert.Equal(t, dnsmessage.TypeA, candidates[0].rrType)
+}
+
+func TestRefreshAllFourThresholds(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+
+	rec := mustBuildA(t, "host.local.", "10.0.0.1", 100)
+	ca.insert(rec, clock.now())
+
+	key := cacheKey{
+		name:    "host.local.",
+		rrType:  dnsmessage.TypeA,
+		rrClass: dnsmessage.ClassINET,
+	}
+
+	var totalCandidates int
+
+	// Advance past each threshold (with jitter margin).
+	// 80% + 2% jitter max = 82s, 85%+2% = 87s, 90%+2% = 92s, 95%+2% = 97s.
+	thresholdTimes := []time.Duration{
+		82 * time.Second,
+		87 * time.Second,
+		92 * time.Second,
+		97 * time.Second,
+	}
+
+	for _, target := range thresholdTimes {
+		elapsed := target - clock.current.Sub(
+			time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		)
+		if elapsed > 0 {
+			clock.advance(elapsed)
+		}
+
+		candidates := ca.dueForRefresh([]cacheKey{key})
+		totalCandidates += len(candidates)
+	}
+
+	assert.Equal(t, 4, totalCandidates)
+}
+
+func TestRefreshResetOnUpdate(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+
+	rec := mustBuildA(t, "host.local.", "192.168.1.1", 100)
+	ca.insert(rec, clock.now())
+
+	key := cacheKey{
+		name:    "host.local.",
+		rrType:  dnsmessage.TypeA,
+		rrClass: dnsmessage.ClassINET,
+	}
+
+	// Advance to 82s, trigger first refresh.
+	clock.advance(82 * time.Second)
+	candidates := ca.dueForRefresh([]cacheKey{key})
+	require.Len(t, candidates, 1)
+
+	// Re-insert same record with new TTL (simulates receiving a refresh response).
+	rec2 := mustBuildA(t, "host.local.", "192.168.1.1", 100)
+	ca.insert(rec2, clock.now())
+
+	// refreshesSent should be reset. Advance to ~82% of new TTL.
+	clock.advance(82 * time.Second)
+	candidates = ca.dueForRefresh([]cacheKey{key})
+	require.Len(t, candidates, 1, "should get refresh candidate after TTL reset")
+}
+
+func TestRefreshOnlyMonitoredKeys(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+
+	// Insert two records.
+	ca.insert(mustBuildA(t, "monitored.local.", "10.0.0.1", 100), clock.now())
+	ca.insert(mustBuildA(t, "unmonitored.local.", "10.0.0.2", 100), clock.now())
+
+	// Only monitor one.
+	monitoredKey := cacheKey{
+		name:    "monitored.local.",
+		rrType:  dnsmessage.TypeA,
+		rrClass: dnsmessage.ClassINET,
+	}
+
+	clock.advance(82 * time.Second)
+	candidates := ca.dueForRefresh([]cacheKey{monitoredKey})
+
+	// Only the monitored record should be a candidate.
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "monitored.local.", candidates[0].name)
+}
+
+func TestRefreshJitter(t *testing.T) {
+	// With 2% jitter on a 100s TTL, the first threshold is between 80s and 82s.
+	// At 81s (fraction=0.81), some attempts should trigger (jitter < 0.01)
+	// and some should not (jitter > 0.01).
+	key := cacheKey{
+		name:    "host.local.",
+		rrType:  dnsmessage.TypeA,
+		rrClass: dnsmessage.ClassINET,
+	}
+
+	triggeredAt81 := 0
+
+	for range 200 {
+		clock := newTestClock()
+		ca := newCache(clock.now)
+
+		rec := mustBuildA(t, "host.local.", "192.168.1.1", 100)
+		ca.insert(rec, clock.now())
+
+		clock.advance(81 * time.Second)
+		candidates := ca.dueForRefresh([]cacheKey{key})
+
+		if len(candidates) > 0 {
+			triggeredAt81++
+		}
+	}
+
+	// At fraction=0.81, triggers when jitter < 0.01 (~50% of [0, 0.02)).
+	// Verify it's not deterministic: some trigger, some don't.
+	assert.Greater(t, triggeredAt81, 0, "should sometimes trigger at 81%%")
+	assert.Less(t, triggeredAt81, 200, "should not always trigger at 81%%")
+}
+
+func TestRefreshExpiredEntrySkipped(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+
+	rec := mustBuildA(t, "host.local.", "192.168.1.1", 100)
+	ca.insert(rec, clock.now())
+
+	key := cacheKey{
+		name:    "host.local.",
+		rrType:  dnsmessage.TypeA,
+		rrClass: dnsmessage.ClassINET,
+	}
+
+	// Advance past TTL expiry.
+	clock.advance(101 * time.Second)
+	candidates := ca.dueForRefresh([]cacheKey{key})
+	assert.Empty(t, candidates)
+}

--- a/refresh_test.go
+++ b/refresh_test.go
@@ -4,9 +4,13 @@
 package mdns
 
 import (
+	"fmt"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/pion/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/dns/dnsmessage"
@@ -62,13 +66,11 @@ func TestRefreshAllFourThresholds(t *testing.T) {
 		97 * time.Second,
 	}
 
+	var elapsed time.Duration
+
 	for _, target := range thresholdTimes {
-		elapsed := target - clock.current.Sub(
-			time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-		)
-		if elapsed > 0 {
-			clock.advance(elapsed)
-		}
+		clock.advance(target - elapsed)
+		elapsed = target
 
 		candidates := ca.dueForRefresh([]cacheKey{key})
 		totalCandidates += len(candidates)
@@ -178,4 +180,211 @@ func TestRefreshExpiredEntrySkipped(t *testing.T) {
 	clock.advance(101 * time.Second)
 	candidates := ca.dueForRefresh([]cacheKey{key})
 	assert.Empty(t, candidates)
+}
+
+func TestRefreshSkipsGoodbyeEntries(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+
+	ca.insert(mustBuildA(t, "host.local.", "192.168.1.1", 100), clock.now())
+
+	// Goodbye the record (TTL=0): retained ~1s but must not be refreshed.
+	ca.insert(mustBuildA(t, "host.local.", "192.168.1.1", 0), clock.now())
+
+	key := cacheKey{
+		name:    "host.local.",
+		rrType:  dnsmessage.TypeA,
+		rrClass: dnsmessage.ClassINET,
+	}
+
+	// 900ms is past 80% of the 1s goodbye retention.
+	clock.advance(900 * time.Millisecond)
+	candidates := ca.dueForRefresh([]cacheKey{key})
+	assert.Empty(t, candidates)
+}
+
+func TestRefreshDuplicateKeysCoalesced(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+
+	ca.insert(mustBuildA(t, "host.local.", "192.168.1.1", 100), clock.now())
+
+	key := cacheKey{
+		name:    "host.local.",
+		rrType:  dnsmessage.TypeA,
+		rrClass: dnsmessage.ClassINET,
+	}
+
+	// The same key monitored by multiple sessions must yield one candidate.
+	clock.advance(82 * time.Second)
+	candidates := ca.dueForRefresh([]cacheKey{key, key, key})
+	assert.Len(t, candidates, 1)
+}
+
+// ---------------------------------------------------------------------------
+// Refresh question sending and background loops
+// ---------------------------------------------------------------------------
+
+// captureWriter is a questionWriter that records written packets.
+type captureWriter struct {
+	mu      sync.Mutex
+	packets [][]byte
+}
+
+func (w *captureWriter) writeQuestion(raw []byte) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.packets = append(w.packets, append([]byte(nil), raw...))
+}
+
+func (w *captureWriter) count() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return len(w.packets)
+}
+
+func TestSendRefreshQuestionsBatching(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	writer := &captureWriter{}
+	cli := newClient(log, "test", writer, true, false, newCache(time.Now))
+
+	// 25 keys batch into 3 messages (10 + 10 + 5).
+	keys := make([]cacheKey, 0, 25)
+	for i := range 25 {
+		keys = append(keys, cacheKey{
+			name:    fmt.Sprintf("host%d.local.", i),
+			rrType:  dnsmessage.TypeA,
+			rrClass: dnsmessage.ClassINET,
+		})
+	}
+
+	cli.sendRefreshQuestions(keys)
+	require.Equal(t, 3, writer.count())
+
+	var total int
+
+	for _, raw := range writer.packets {
+		var msg dnsmessage.Message
+
+		require.NoError(t, msg.Unpack(raw))
+		assert.False(t, msg.Response)
+		total += len(msg.Questions)
+	}
+
+	assert.Equal(t, 25, total)
+}
+
+func TestSendRefreshQuestionsSkipsInvalidName(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	writer := &captureWriter{}
+	cli := newClient(log, "test", writer, true, false, newCache(time.Now))
+
+	keys := []cacheKey{
+		// Longer than the 255-byte DNS name limit: dropped with a warning.
+		{name: strings.Repeat("a", 300) + ".", rrType: dnsmessage.TypeA, rrClass: dnsmessage.ClassINET},
+		{name: "ok.local.", rrType: dnsmessage.TypeAAAA, rrClass: dnsmessage.ClassINET},
+	}
+
+	cli.sendRefreshQuestions(keys)
+	require.Equal(t, 1, writer.count())
+
+	var msg dnsmessage.Message
+
+	require.NoError(t, msg.Unpack(writer.packets[0]))
+	require.Len(t, msg.Questions, 1)
+	assert.Equal(t, "ok.local.", msg.Questions[0].Name.String())
+	assert.Equal(t, dnsmessage.TypeAAAA, msg.Questions[0].Type)
+}
+
+func TestAnswerHandlerMonitoredCacheKeys(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
+
+	assert.Empty(t, handler.monitoredCacheKeys())
+
+	browse := newBrowseSession(t.Context(), "_http._tcp", func(ServiceEvent) {})
+	handler.registerBrowseSession(browse)
+
+	enum := newEnumerateSession(t.Context(), func(string) {})
+	handler.registerEnumerateSession(enum)
+
+	keys := handler.monitoredCacheKeys()
+	require.Len(t, keys, 2)
+	assert.Equal(t, "_http._tcp.local.", keys[0].name)
+	assert.Equal(t, "_services._dns-sd._udp.local.", keys[1].name)
+}
+
+func TestRefreshLoopSendsQuestions(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	writer := &captureWriter{}
+	ca := newCache(time.Now)
+	cli := newClient(log, "test", writer, true, false, ca)
+
+	browse := newBrowseSession(t.Context(), "_http._tcp", func(ServiceEvent) {})
+	cli.handler.registerBrowseSession(browse)
+
+	// Insert a monitored PTR record already past its first refresh threshold.
+	rec := mustBuildPTR(t, "_http._tcp.local.", "My Web._http._tcp.local.", 100)
+	ca.insert(rec, time.Now().Add(-99*time.Second))
+
+	conn := &Conn{
+		client:               cli,
+		cache:                ca,
+		stopBackground:       make(chan struct{}),
+		cacheRefresh:         true,
+		refreshCheckInterval: 10 * time.Millisecond,
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		conn.refreshLoop()
+	}()
+
+	assert.Eventually(t, func() bool {
+		return writer.count() > 0
+	}, time.Second, 10*time.Millisecond)
+
+	close(conn.stopBackground)
+	<-done
+
+	var msg dnsmessage.Message
+
+	require.NoError(t, msg.Unpack(writer.packets[0]))
+	require.NotEmpty(t, msg.Questions)
+	assert.Equal(t, "_http._tcp.local.", msg.Questions[0].Name.String())
+	assert.Equal(t, dnsmessage.TypePTR, msg.Questions[0].Type)
+}
+
+func TestSweepLoopRemovesExpired(t *testing.T) {
+	ca := newCache(time.Now)
+
+	// Insert a record that expired one second ago.
+	ca.insert(mustBuildA(t, "host.local.", "10.0.0.1", 1), time.Now().Add(-2*time.Second))
+
+	conn := &Conn{
+		cache:          ca,
+		stopBackground: make(chan struct{}),
+		sweepInterval:  10 * time.Millisecond,
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		conn.sweepLoop()
+	}()
+
+	assert.Eventually(t, func() bool {
+		ca.mu.RLock()
+		defer ca.mu.RUnlock()
+
+		return len(ca.entries) == 0
+	}, time.Second, 10*time.Millisecond)
+
+	close(conn.stopBackground)
+	<-done
 }

--- a/refresh_test.go
+++ b/refresh_test.go
@@ -221,6 +221,61 @@ func TestRefreshDuplicateKeysCoalesced(t *testing.T) {
 	assert.Len(t, candidates, 1)
 }
 
+func TestRefreshMultiHomedKeyYieldsOneCandidate(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+
+	// Multi-homed host: three A records under the same cache key.
+	ca.insert(mustBuildA(t, "host.local.", "192.168.1.1", 100), clock.now())
+	ca.insert(mustBuildA(t, "host.local.", "192.168.1.2", 100), clock.now())
+	ca.insert(mustBuildA(t, "host.local.", "192.168.1.3", 100), clock.now())
+
+	key := cacheKey{
+		name:    "host.local.",
+		rrType:  dnsmessage.TypeA,
+		rrClass: dnsmessage.ClassINET,
+	}
+
+	// A fourth address learned 5s later: its thresholds are staggered.
+	clock.advance(5 * time.Second)
+	ca.insert(mustBuildA(t, "host.local.", "192.168.1.4", 100), clock.now())
+
+	// At 82s all three original entries are past 80%+jitter, yet one
+	// question refreshes every record under the key: one candidate.
+	clock.advance(77 * time.Second)
+	candidates := ca.takeRefreshCandidates([]cacheKey{key})
+	assert.Len(t, candidates, 1)
+
+	// All due entries consumed their threshold: nothing due right after.
+	assert.Empty(t, ca.takeRefreshCandidates([]cacheKey{key}))
+
+	// At 87s the originals reach 85%+jitter and the staggered entry
+	// reaches its first threshold (82% elapsed of its own TTL): still
+	// coalesced into a single candidate.
+	clock.advance(5 * time.Second)
+	candidates = ca.takeRefreshCandidates([]cacheKey{key})
+	assert.Len(t, candidates, 1)
+
+	// Counters advanced per entry: 2 for the originals, 1 for the late one.
+	ca.mu.RLock()
+	sent := make(map[string]uint8, 4)
+	for _, entry := range ca.entries[key] {
+		body, ok := entry.resource.Body.(*dnsmessage.AResource)
+		require.True(t, ok)
+		addr := fmt.Sprintf("%d.%d.%d.%d", body.A[0], body.A[1], body.A[2], body.A[3])
+		sent[addr] = entry.refreshesSent
+	}
+	ca.mu.RUnlock()
+
+	expected := map[string]uint8{
+		"192.168.1.1": 2,
+		"192.168.1.2": 2,
+		"192.168.1.3": 2,
+		"192.168.1.4": 1,
+	}
+	assert.Equal(t, expected, sent)
+}
+
 // ---------------------------------------------------------------------------
 // Refresh question sending and background loops
 // ---------------------------------------------------------------------------

--- a/refresh_test.go
+++ b/refresh_test.go
@@ -31,12 +31,12 @@ func TestRefreshAt80Percent(t *testing.T) {
 
 	// At 79s — not yet due.
 	clock.advance(79 * time.Second)
-	candidates := ca.dueForRefresh([]cacheKey{key})
+	candidates := ca.takeRefreshCandidates([]cacheKey{key})
 	assert.Empty(t, candidates)
 
 	// At 82s — past 80% threshold (even with up to 2% jitter = 82%).
 	clock.advance(3 * time.Second)
-	candidates = ca.dueForRefresh([]cacheKey{key})
+	candidates = ca.takeRefreshCandidates([]cacheKey{key})
 	require.Len(t, candidates, 1)
 	assert.Equal(t, "host.local.", candidates[0].name)
 	assert.Equal(t, dnsmessage.TypeA, candidates[0].rrType)
@@ -72,7 +72,7 @@ func TestRefreshAllFourThresholds(t *testing.T) {
 		clock.advance(target - elapsed)
 		elapsed = target
 
-		candidates := ca.dueForRefresh([]cacheKey{key})
+		candidates := ca.takeRefreshCandidates([]cacheKey{key})
 		totalCandidates += len(candidates)
 	}
 
@@ -94,7 +94,7 @@ func TestRefreshResetOnUpdate(t *testing.T) {
 
 	// Advance to 82s, trigger first refresh.
 	clock.advance(82 * time.Second)
-	candidates := ca.dueForRefresh([]cacheKey{key})
+	candidates := ca.takeRefreshCandidates([]cacheKey{key})
 	require.Len(t, candidates, 1)
 
 	// Re-insert same record with new TTL (simulates receiving a refresh response).
@@ -103,7 +103,7 @@ func TestRefreshResetOnUpdate(t *testing.T) {
 
 	// refreshesSent should be reset. Advance to ~82% of new TTL.
 	clock.advance(82 * time.Second)
-	candidates = ca.dueForRefresh([]cacheKey{key})
+	candidates = ca.takeRefreshCandidates([]cacheKey{key})
 	require.Len(t, candidates, 1, "should get refresh candidate after TTL reset")
 }
 
@@ -123,7 +123,7 @@ func TestRefreshOnlyMonitoredKeys(t *testing.T) {
 	}
 
 	clock.advance(82 * time.Second)
-	candidates := ca.dueForRefresh([]cacheKey{monitoredKey})
+	candidates := ca.takeRefreshCandidates([]cacheKey{monitoredKey})
 
 	// Only the monitored record should be a candidate.
 	require.Len(t, candidates, 1)
@@ -150,7 +150,7 @@ func TestRefreshJitter(t *testing.T) {
 		ca.insert(rec, clock.now())
 
 		clock.advance(81 * time.Second)
-		candidates := ca.dueForRefresh([]cacheKey{key})
+		candidates := ca.takeRefreshCandidates([]cacheKey{key})
 
 		if len(candidates) > 0 {
 			triggeredAt81++
@@ -178,7 +178,7 @@ func TestRefreshExpiredEntrySkipped(t *testing.T) {
 
 	// Advance past TTL expiry.
 	clock.advance(101 * time.Second)
-	candidates := ca.dueForRefresh([]cacheKey{key})
+	candidates := ca.takeRefreshCandidates([]cacheKey{key})
 	assert.Empty(t, candidates)
 }
 
@@ -199,7 +199,7 @@ func TestRefreshSkipsGoodbyeEntries(t *testing.T) {
 
 	// 900ms is past 80% of the 1s goodbye retention.
 	clock.advance(900 * time.Millisecond)
-	candidates := ca.dueForRefresh([]cacheKey{key})
+	candidates := ca.takeRefreshCandidates([]cacheKey{key})
 	assert.Empty(t, candidates)
 }
 
@@ -217,7 +217,7 @@ func TestRefreshDuplicateKeysCoalesced(t *testing.T) {
 
 	// The same key monitored by multiple sessions must yield one candidate.
 	clock.advance(82 * time.Second)
-	candidates := ca.dueForRefresh([]cacheKey{key, key, key})
+	candidates := ca.takeRefreshCandidates([]cacheKey{key, key, key})
 	assert.Len(t, candidates, 1)
 }
 

--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pion/logging"
 	"golang.org/x/net/dns/dnsmessage"
@@ -268,6 +269,15 @@ type serverConfig struct {
 
 	// services are the DNS-SD services to advertise (RFC 6763).
 	services []ServiceInstance
+
+	// cacheRefresh enables proactive cache refresh per RFC 6762 §5.2.
+	// When true, actively-monitored records are re-queried at 80/85/90/95%
+	// of their TTL. Defaults to true for NewServer, false for legacy Server.
+	cacheRefresh bool
+
+	// refreshCheckInterval is how often the refresh loop checks for
+	// records due for refresh. Zero means use defaultRefreshCheckInterval.
+	refreshCheckInterval time.Duration
 }
 
 // NewServer creates a new mDNS server with the given options.
@@ -301,7 +311,7 @@ func NewServer(
 	opts ...ServerOption,
 ) (*Conn, error) {
 	// Apply options to config
-	cfg := &serverConfig{}
+	cfg := &serverConfig{cacheRefresh: true}
 	for _, opt := range opts {
 		if err := opt.applyServer(cfg); err != nil {
 			return nil, err
@@ -320,9 +330,13 @@ func NewServer(
 	}
 
 	conn := &Conn{
-		queryInterval: defaultQueryInterval,
-		log:           log,
-		closed:        make(chan any),
+		queryInterval:        defaultQueryInterval,
+		log:                  log,
+		cache:                newCache(time.Now),
+		stopBackground:       make(chan struct{}),
+		cacheRefresh:         cfg.cacheRefresh,
+		refreshCheckInterval: cfg.refreshCheckInterval,
+		closed:               make(chan any),
 	}
 	conn.name = cfg.name
 	if conn.name == "" {
@@ -510,6 +524,7 @@ func NewServer(
 		conn, // Conn implements questionWriter
 		multicastPktConnV4 != nil,
 		multicastPktConnV6 != nil,
+		conn.cache,
 	)
 	// Ensure each service has the host set to the server's hostname.
 	for i := range cfg.services {
@@ -581,6 +596,8 @@ func Server(
 	opts := []ServerOption{
 		// Legacy behavior: only handle A/AAAA records (WebRTC/ICE compatibility)
 		WithRecordTypes(dnsmessage.TypeA, dnsmessage.TypeAAAA),
+		// Legacy behavior: no proactive cache refresh.
+		WithCacheRefresh(false),
 	}
 	if config.Name != "" {
 		opts = append(opts, WithName(config.Name))

--- a/server_test.go
+++ b/server_test.go
@@ -10,6 +10,7 @@ import (
 	"net/netip"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pion/logging"
 	"github.com/stretchr/testify/assert"
@@ -232,6 +233,25 @@ func TestWithResponseTTLZero(t *testing.T) {
 	err := WithResponseTTL(0).applyServer(cfg)
 	assert.ErrorIs(t, err, errResponseTTLZero)
 	assert.Zero(t, cfg.responseTTL)
+}
+
+func TestWithRefreshInterval(t *testing.T) {
+	cfg := &serverConfig{}
+
+	err := WithRefreshInterval(5 * time.Second).applyServer(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, 5*time.Second, cfg.refreshCheckInterval)
+}
+
+func TestWithRefreshIntervalNonPositive(t *testing.T) {
+	cfg := &serverConfig{}
+
+	err := WithRefreshInterval(0).applyServer(cfg)
+	assert.ErrorIs(t, err, errRefreshIntervalNonPositive)
+
+	err = WithRefreshInterval(-time.Second).applyServer(cfg)
+	assert.ErrorIs(t, err, errRefreshIntervalNonPositive)
+	assert.Zero(t, cfg.refreshCheckInterval)
 }
 
 func TestOptionsImplementInterfaces(t *testing.T) {


### PR DESCRIPTION
## Summary

- Wire the cache from #266 into the mDNS event loop: insert all answer/additional records on receive
- Periodic sweep of expired entries (10s default)
- Proactive cache refresh at 80/85/90/95% of TTL per RFC 6762 §5.2
- `WithCacheRefresh(bool)` and `WithRefreshInterval(time.Duration)` server options
- Refresh enabled by default in `NewServer`, disabled in legacy `Server()` to preserve existing behavior

Builds on #266 (record cache with TTL management). This PR supersedes #266 — the commits from #266 are included here. Both can be merged separately (cache first, then integration) or together via this PR.