### PR TITLE
Add probing, announcing and conflict resolution (RFC 6762 §8-9)

### DIFF
--- a/config.go
+++ b/config.go
@@ -295,6 +295,25 @@ func (o cacheRefreshOption) applyServer(c *serverConfig) error {
 	return nil
 }
 
+// probingOption controls RFC 6762 §8 name probing.
+type probingOption bool
+
+// WithProbing enables or disables name probing (RFC 6762 §8).
+// When enabled (the default for NewServer), the server probes for name
+// uniqueness before claiming records and announces them afterward.
+// Legacy Server() disables probing since WebRTC UUIDs are unique by
+// construction.
+func WithProbing(enabled bool) probingOption {
+	return probingOption(enabled)
+}
+
+func (o probingOption) applyServer(c *serverConfig) error {
+	v := bool(o)
+	c.probing = &v
+
+	return nil
+}
+
 // refreshIntervalOption sets the refresh check interval.
 type refreshIntervalOption time.Duration
 
@@ -311,6 +330,28 @@ func (o refreshIntervalOption) applyServer(c *serverConfig) error {
 	}
 
 	c.refreshCheckInterval = time.Duration(o)
+
+	return nil
+}
+
+// conflictHandlerOption sets the conflict handler callback.
+type conflictHandlerOption struct {
+	handler func(ConflictEvent) ConflictAction
+}
+
+// WithConflictHandler sets a callback invoked when a naming conflict is
+// detected during probing (RFC 6762 §9). The handler can return a custom
+// rename or signal to stop retrying. If not set, the default strategy
+// appends " (N)" for service instances and "-N" for hostnames.
+//
+// This is useful when a higher-level protocol (e.g. Matter, AirPlay)
+// specifies its own naming/renaming strategy.
+func WithConflictHandler(handler func(ConflictEvent) ConflictAction) conflictHandlerOption {
+	return conflictHandlerOption{handler: handler}
+}
+
+func (o conflictHandlerOption) applyServer(c *serverConfig) error {
+	c.conflictHandler = o.handler
 
 	return nil
 }

--- a/conn.go
+++ b/conn.go
@@ -175,6 +175,10 @@ func (c *Conn) WaitReady(ctx context.Context) error {
 // Register adds a DNS-SD service instance to the server.
 // The service will be advertised in response to PTR, SRV, and TXT queries.
 // Returns an error if the connection is closed or has no server.
+//
+// Services registered after startup are not probed or announced (RFC 6762
+// §8); probing covers only services passed via WithService. Dynamic
+// probing is a planned follow-up.
 func (c *Conn) Register(svc ServiceInstance) error {
 	select {
 	case <-c.closed:

--- a/conn.go
+++ b/conn.go
@@ -61,6 +61,9 @@ type Conn struct {
 	// onServiceTypeDiscovered is the handler for EnumerateServiceTypes results.
 	onServiceTypeDiscovered atomic.Value // func(string)
 
+	// onConflict is the handler for naming conflicts during probing (RFC 6762 §9).
+	onConflict atomic.Value // func(ConflictEvent) ConflictAction
+
 	closed chan any
 }
 
@@ -151,6 +154,24 @@ func (c *Conn) Close() error { //nolint:cyclop
 	return rtrn
 }
 
+// WaitReady blocks until the initial name probing is complete (all names
+// established) or the context expires. Returns nil immediately if probing
+// is disabled.
+func (c *Conn) WaitReady(ctx context.Context) error {
+	if c.server == nil || c.server.probes == nil {
+		return nil
+	}
+
+	select {
+	case <-c.server.probes.ready:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.closed:
+		return errConnectionClosed
+	}
+}
+
 // Register adds a DNS-SD service instance to the server.
 // The service will be advertised in response to PTR, SRV, and TXT queries.
 // Returns an error if the connection is closed or has no server.
@@ -222,6 +243,21 @@ func (c *Conn) serviceTypeDiscoveredHandler(serviceType string) {
 	if handler, ok := c.onServiceTypeDiscovered.Load().(func(string)); ok && handler != nil {
 		handler(serviceType)
 	}
+}
+
+// setConflictHandler stores the conflict handler atomically.
+// Expose as OnConflict once the probing API is mature.
+func (c *Conn) setConflictHandler(handler func(ConflictEvent) ConflictAction) {
+	c.onConflict.Store(handler)
+}
+
+// conflictHandler dispatches a ConflictEvent to the registered handler.
+func (c *Conn) conflictHandler(evt ConflictEvent) ConflictAction {
+	if handler, ok := c.onConflict.Load().(func(ConflictEvent) ConflictAction); ok && handler != nil {
+		return handler(evt)
+	}
+
+	return ConflictAction{}
 }
 
 // Browse starts discovering DNS-SD service instances of the given type on
@@ -548,34 +584,40 @@ func (c *Conn) readLoop(name string, pktConn ipPacketConn, inboundBufferSize int
 			continue
 		}
 
-		func() {
-			var msg dnsmessage.Message
-			err := msg.Unpack(b[:n])
-			if err != nil {
-				c.log.Warnf("[%s] failed to parse mDNS packet %v", c.name, err)
+		c.handleRawPacket(b[:n], srcAddr, ifIndex, pktDst)
+	}
+}
 
-				return
-			}
+func (c *Conn) handleRawPacket(raw []byte, srcAddr *net.UDPAddr, ifIndex int, pktDst net.IP) {
+	var msg dnsmessage.Message
+	if err := msg.Unpack(raw); err != nil {
+		c.log.Warnf("[%s] failed to parse mDNS packet %v", c.name, err)
 
-			ctx := &messageContext{
-				source:    srcAddr,
-				ifIndex:   ifIndex,
-				pktDst:    pktDst,
-				timestamp: time.Now(),
-			}
+		return
+	}
 
-			// Questions are often echoed with answers, therefore
-			// If we have more questions than answers it is a question we might need to respond to
-			if len(msg.Questions) > len(msg.Answers) {
-				if c.server != nil {
-					c.server.handler.handle(ctx, &msg)
-				}
-			} else {
-				if c.client != nil {
-					c.client.handler.handle(ctx, &msg)
-				}
-			}
-		}()
+	ctx := &messageContext{
+		source:    srcAddr,
+		ifIndex:   ifIndex,
+		pktDst:    pktDst,
+		timestamp: time.Now(),
+	}
+
+	// Feed to probe manager for conflict detection (§8).
+	if c.server != nil && c.server.probes != nil {
+		c.server.probes.handleMessage(&msg)
+	}
+
+	// Questions are often echoed with answers, therefore
+	// If we have more questions than answers it is a question we might need to respond to
+	if len(msg.Questions) > len(msg.Answers) {
+		if c.server != nil {
+			c.server.handler.handle(ctx, &msg)
+		}
+	} else {
+		if c.client != nil {
+			c.client.handler.handle(ctx, &msg)
+		}
 	}
 }
 
@@ -635,6 +677,12 @@ func (c *Conn) start(started chan<- struct{}, inboundBufferSize int, config *ser
 	for i := 0; i < numReaders; i++ {
 		<-readerStarted
 	}
+
+	// Start probing after readers so we can receive responses.
+	if c.server != nil && c.server.probes != nil {
+		go c.server.probes.run(c.closed)
+	}
+
 	close(started)
 	for i := 0; i < numReaders; i++ {
 		<-readerEnded

--- a/conn.go
+++ b/conn.go
@@ -243,18 +243,18 @@ func (c *Conn) UpdateTXT(instance, service string, text []TXTEntry) error {
 		return err
 	}
 
-	go c.repeatTXTAnnouncement(instance, service, generation)
+	go c.repeatTXTAnnouncement(generation)
 
 	return nil
 }
 
-func (c *Conn) repeatTXTAnnouncement(instance, service string, generation uint64) {
+func (c *Conn) repeatTXTAnnouncement(generation uint64) {
 	timer := time.NewTimer(time.Second)
 	defer timer.Stop()
 
 	select {
 	case <-timer.C:
-		if err := c.server.repeatTXTAnnouncement(instance, service, generation); err != nil {
+		if err := c.server.repeatTXTAnnouncement(generation); err != nil {
 			c.log.Warnf("[%s] failed to repeat TXT announcement: %v", c.name, err)
 		}
 	case <-c.closed:

--- a/conn.go
+++ b/conn.go
@@ -61,6 +61,9 @@ type Conn struct {
 	// onServiceTypeDiscovered is the handler for EnumerateServiceTypes results.
 	onServiceTypeDiscovered atomic.Value // func(string)
 
+	// onConflict is the handler for naming conflicts during probing (RFC 6762 §9).
+	onConflict atomic.Value // func(ConflictEvent) ConflictAction
+
 	closed chan any
 }
 
@@ -149,6 +152,24 @@ func (c *Conn) Close() error { //nolint:cyclop
 	}
 
 	return rtrn
+}
+
+// WaitReady blocks until the initial name probing is complete (all names
+// established) or the context expires. Returns nil immediately if probing
+// is disabled.
+func (c *Conn) WaitReady(ctx context.Context) error {
+	if c.server == nil || c.server.probes == nil {
+		return nil
+	}
+
+	select {
+	case <-c.server.probes.ready:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.closed:
+		return errConnectionClosed
+	}
 }
 
 // Register adds a DNS-SD service instance to the server.
@@ -272,6 +293,21 @@ func (c *Conn) serviceTypeDiscoveredHandler(serviceType string) {
 	if handler, ok := c.onServiceTypeDiscovered.Load().(func(string)); ok && handler != nil {
 		handler(serviceType)
 	}
+}
+
+// setConflictHandler stores the conflict handler atomically.
+// Expose as OnConflict once the probing API is mature.
+func (c *Conn) setConflictHandler(handler func(ConflictEvent) ConflictAction) {
+	c.onConflict.Store(handler)
+}
+
+// conflictHandler dispatches a ConflictEvent to the registered handler.
+func (c *Conn) conflictHandler(evt ConflictEvent) ConflictAction {
+	if handler, ok := c.onConflict.Load().(func(ConflictEvent) ConflictAction); ok && handler != nil {
+		return handler(evt)
+	}
+
+	return ConflictAction{}
 }
 
 // Browse starts discovering DNS-SD service instances of the given type on
@@ -598,34 +634,40 @@ func (c *Conn) readLoop(name string, pktConn ipPacketConn, inboundBufferSize int
 			continue
 		}
 
-		func() {
-			var msg dnsmessage.Message
-			err := msg.Unpack(b[:n])
-			if err != nil {
-				c.log.Warnf("[%s] failed to parse mDNS packet %v", c.name, err)
+		c.handleRawPacket(b[:n], srcAddr, ifIndex, pktDst)
+	}
+}
 
-				return
-			}
+func (c *Conn) handleRawPacket(raw []byte, srcAddr *net.UDPAddr, ifIndex int, pktDst net.IP) {
+	var msg dnsmessage.Message
+	if err := msg.Unpack(raw); err != nil {
+		c.log.Warnf("[%s] failed to parse mDNS packet %v", c.name, err)
 
-			ctx := &messageContext{
-				source:    srcAddr,
-				ifIndex:   ifIndex,
-				pktDst:    pktDst,
-				timestamp: time.Now(),
-			}
+		return
+	}
 
-			// Questions are often echoed with answers, therefore
-			// If we have more questions than answers it is a question we might need to respond to
-			if len(msg.Questions) > len(msg.Answers) {
-				if c.server != nil {
-					c.server.handler.handle(ctx, &msg)
-				}
-			} else {
-				if c.client != nil {
-					c.client.handler.handle(ctx, &msg)
-				}
-			}
-		}()
+	ctx := &messageContext{
+		source:    srcAddr,
+		ifIndex:   ifIndex,
+		pktDst:    pktDst,
+		timestamp: time.Now(),
+	}
+
+	// Feed to probe manager for conflict detection (§8).
+	if c.server != nil && c.server.probes != nil {
+		c.server.probes.handleMessage(&msg)
+	}
+
+	// Questions are often echoed with answers, therefore
+	// If we have more questions than answers it is a question we might need to respond to
+	if len(msg.Questions) > len(msg.Answers) {
+		if c.server != nil {
+			c.server.handler.handle(ctx, &msg)
+		}
+	} else {
+		if c.client != nil {
+			c.client.handler.handle(ctx, &msg)
+		}
 	}
 }
 
@@ -685,6 +727,12 @@ func (c *Conn) start(started chan<- struct{}, inboundBufferSize int, config *ser
 	for i := 0; i < numReaders; i++ {
 		<-readerStarted
 	}
+
+	// Start probing after readers so we can receive responses.
+	if c.server != nil && c.server.probes != nil {
+		go c.server.probes.run(c.closed)
+	}
+
 	close(started)
 	for i := 0; i < numReaders; i++ {
 		<-readerEnded

--- a/conn_test.go
+++ b/conn_test.go
@@ -459,8 +459,8 @@ func TestValidCommunicationIPv6(t *testing.T) { //nolint:cyclop
 
 	assert.NotEqualf(t, localAddress, addr.String(), "unexpected local address: %v", addr)
 	checkIPv6(t, addr)
-	if !addr.Is4In6() {
-		assert.NotEqualf(t, "", addr.Zone(), "expected IPv6 to have zone but got %s", addr)
+	if !addr.Is4In6() && (addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast()) {
+		assert.NotEqualf(t, "", addr.Zone(), "expected link-local IPv6 to have zone but got %s", addr)
 	}
 
 	assert.NoError(t, aServer.Close())

--- a/conn_test.go
+++ b/conn_test.go
@@ -1473,6 +1473,37 @@ func TestDynamicRegisterAndBrowse(t *testing.T) {
 	assert.NoError(t, bServer.Close())
 }
 
+func TestConflictCallbackAtomic(t *testing.T) {
+	// Verify the atomic.Value callback pattern works for conflict handler.
+	var conn Conn
+
+	// No handler: should return zero-value action.
+	action := conn.conflictHandler(ConflictEvent{Name: "test.local.", Count: 1})
+	assert.False(t, action.Stop)
+	assert.Equal(t, "", action.Rename)
+
+	// Set handler: should be invoked.
+	var captured ConflictEvent
+	conn.setConflictHandler(func(evt ConflictEvent) ConflictAction {
+		captured = evt
+
+		return ConflictAction{Rename: "custom.local."}
+	})
+
+	action = conn.conflictHandler(ConflictEvent{Name: "myhost.local.", Count: 2, Host: true})
+	assert.Equal(t, "myhost.local.", captured.Name)
+	assert.Equal(t, 2, captured.Count)
+	assert.True(t, captured.Host)
+	assert.Equal(t, "custom.local.", action.Rename)
+
+	// Clear handler: should return zero-value again.
+	conn.setConflictHandler(nil)
+
+	action = conn.conflictHandler(ConflictEvent{Name: "test.local.", Count: 1})
+	assert.False(t, action.Stop)
+	assert.Equal(t, "", action.Rename)
+}
+
 func TestIPToBytes(t *testing.T) { //nolint:cyclop
 	expectedIP := []byte{127, 0, 0, 1}
 	actualAddr4, err := ipv4ToBytes(netip.MustParseAddr("127.0.0.1"))

--- a/conn_test.go
+++ b/conn_test.go
@@ -1504,6 +1504,47 @@ func TestConflictCallbackAtomic(t *testing.T) {
 	assert.Equal(t, "", action.Rename)
 }
 
+func TestWaitReadyNilProbes(t *testing.T) {
+	// No probing configured: WaitReady returns nil immediately.
+	var conn Conn
+	conn.closed = make(chan any)
+
+	err := conn.WaitReady(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestWaitReadyContextCancellation(t *testing.T) {
+	var conn Conn
+	conn.closed = make(chan any)
+	conn.server = &server{
+		probes: &probeManager{
+			ready: make(chan struct{}), // never closed.
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately.
+
+	err := conn.WaitReady(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestWaitReadyConnClosed(t *testing.T) {
+	conn := &Conn{
+		closed: make(chan any),
+		server: &server{
+			probes: &probeManager{
+				ready: make(chan struct{}), // never closed.
+			},
+		},
+	}
+
+	close(conn.closed)
+
+	err := conn.WaitReady(context.Background())
+	assert.ErrorIs(t, err, errConnectionClosed)
+}
+
 func TestIPToBytes(t *testing.T) { //nolint:cyclop
 	expectedIP := []byte{127, 0, 0, 1}
 	actualAddr4, err := ipv4ToBytes(netip.MustParseAddr("127.0.0.1"))

--- a/conn_test.go
+++ b/conn_test.go
@@ -1506,6 +1506,47 @@ func TestConflictCallbackAtomic(t *testing.T) {
 	assert.Equal(t, "", action.Rename)
 }
 
+func TestWaitReadyNilProbes(t *testing.T) {
+	// No probing configured: WaitReady returns nil immediately.
+	var conn Conn
+	conn.closed = make(chan any)
+
+	err := conn.WaitReady(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestWaitReadyContextCancellation(t *testing.T) {
+	var conn Conn
+	conn.closed = make(chan any)
+	conn.server = &server{
+		probes: &probeManager{
+			ready: make(chan struct{}), // never closed.
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately.
+
+	err := conn.WaitReady(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestWaitReadyConnClosed(t *testing.T) {
+	conn := &Conn{
+		closed: make(chan any),
+		server: &server{
+			probes: &probeManager{
+				ready: make(chan struct{}), // never closed.
+			},
+		},
+	}
+
+	close(conn.closed)
+
+	err := conn.WaitReady(context.Background())
+	assert.ErrorIs(t, err, errConnectionClosed)
+}
+
 func TestIPToBytes(t *testing.T) { //nolint:cyclop
 	expectedIP := []byte{127, 0, 0, 1}
 	actualAddr4, err := ipv4ToBytes(netip.MustParseAddr("127.0.0.1"))

--- a/conn_test.go
+++ b/conn_test.go
@@ -1475,6 +1475,37 @@ func TestDynamicRegisterAndBrowse(t *testing.T) {
 	assert.NoError(t, bServer.Close())
 }
 
+func TestConflictCallbackAtomic(t *testing.T) {
+	// Verify the atomic.Value callback pattern works for conflict handler.
+	var conn Conn
+
+	// No handler: should return zero-value action.
+	action := conn.conflictHandler(ConflictEvent{Name: "test.local.", Count: 1})
+	assert.False(t, action.Stop)
+	assert.Equal(t, "", action.Rename)
+
+	// Set handler: should be invoked.
+	var captured ConflictEvent
+	conn.setConflictHandler(func(evt ConflictEvent) ConflictAction {
+		captured = evt
+
+		return ConflictAction{Rename: "custom.local."}
+	})
+
+	action = conn.conflictHandler(ConflictEvent{Name: "myhost.local.", Count: 2, Host: true})
+	assert.Equal(t, "myhost.local.", captured.Name)
+	assert.Equal(t, 2, captured.Count)
+	assert.True(t, captured.Host)
+	assert.Equal(t, "custom.local.", action.Rename)
+
+	// Clear handler: should return zero-value again.
+	conn.setConflictHandler(nil)
+
+	action = conn.conflictHandler(ConflictEvent{Name: "test.local.", Count: 1})
+	assert.False(t, action.Stop)
+	assert.Equal(t, "", action.Rename)
+}
+
 func TestIPToBytes(t *testing.T) { //nolint:cyclop
 	expectedIP := []byte{127, 0, 0, 1}
 	actualAddr4, err := ipv4ToBytes(netip.MustParseAddr("127.0.0.1"))

--- a/probe.go
+++ b/probe.go
@@ -1,0 +1,972 @@
+// SPDX-FileCopyrightText: The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package mdns
+
+import (
+	"bytes"
+	"cmp"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pion/logging"
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+// Probing constants per RFC 6762 §8.
+const (
+	// probeDelay is the maximum random delay before the first probe (§8.1).
+	probeDelay = 250 * time.Millisecond
+
+	// probeInterval is the time between successive probe queries (§8.1).
+	probeInterval = 250 * time.Millisecond
+
+	// probeCount is the number of probe queries to send (§8.1).
+	probeCount = 3
+
+	// announceInterval is the time between unsolicited announcements (§8.3).
+	announceInterval = 1 * time.Second
+
+	// announceCount is the number of unsolicited announcements to send (§8.3).
+	announceCount = 2
+
+	// conflictRateWindow is the sliding window for rate limiting (§8.1).
+	conflictRateWindow = 10 * time.Second
+
+	// conflictRateLimit is the max conflicts before backoff kicks in (§8.1).
+	conflictRateLimit = 15
+
+	// conflictBackoff is the delay when rate limited (§8.1).
+	conflictBackoff = 5 * time.Second
+
+	// conflictGiveUp is the total duration of continuous conflicts before
+	// we stop retrying a name.
+	conflictGiveUp = 60 * time.Second
+
+	// typeANY is the QTYPE for "ANY" queries (RFC 1035 §3.2.3).
+	typeANY = dnsmessage.TypeALL // 255
+)
+
+// probeTimer abstracts time.Timer for testability.
+type probeTimer interface {
+	Chan() <-chan time.Time
+	Stop() bool
+}
+
+// realTimer wraps time.Timer to implement probeTimer.
+type realTimer struct{ *time.Timer }
+
+func (t *realTimer) Chan() <-chan time.Time { return t.Timer.C }
+func (t *realTimer) Stop() bool             { return t.Timer.Stop() }
+
+func newRealTimer(d time.Duration) probeTimer {
+	return &realTimer{time.NewTimer(d)}
+}
+
+// ConflictEvent describes a naming conflict detected during probing
+// or in established state (RFC 6762 §9). Passed to a user-provided
+// conflict handler so it can influence rename behavior.
+type ConflictEvent struct {
+	// Name is the conflicting DNS name (FQDN with trailing dot).
+	Name string
+
+	// Count is the number of times this name has conflicted (1-based).
+	Count int
+
+	// Host is true when the conflicting name is a hostname (A/AAAA),
+	// false when it is a service instance name (SRV/TXT).
+	Host bool
+}
+
+// ConflictAction tells the probing system how to handle a naming conflict.
+type ConflictAction struct {
+	// Rename is the replacement DNS name to probe next. If empty, the
+	// default rename strategy is used (append " (N)" for services,
+	// "-N" for hostnames).
+	Rename string
+
+	// Stop signals that probing should stop for this name. No further
+	// rename attempts will be made.
+	Stop bool
+}
+
+// probeState represents the current phase of a probe session.
+type probeState int
+
+const (
+	probeStateDelay       probeState = iota // random 0–250 ms wait.
+	probeStateProbing                       // sending 3 probes at 250 ms.
+	probeStateAnnouncing                    // sending 2 announcements at 1 s.
+	probeStateEstablished                   // name claimed.
+	probeStateStopped                       // gave up or user stopped.
+)
+
+// probeSession tracks the probing lifecycle for a single DNS name.
+type probeSession struct {
+	name    string                // FQDN being probed (e.g. "myhost.local.").
+	records []dnsmessage.Resource // proposed records (authority / announce).
+	isHost  bool                  // hostname vs service instance.
+
+	state         probeState
+	probesSent    int
+	announcesSent int
+	nextEvent     time.Time
+
+	conflictCount int
+	conflictTimes []time.Time // for rate limiting.
+	firstConflict time.Time   // for give-up timeout.
+	conflict      bool        // flag set by message handler.
+	tiebreakDefer bool        // flag set by simultaneous probe handler.
+}
+
+// pendingIO collects I/O operations determined under the lock, to be
+// executed after the lock is released (avoids holding mu during sends).
+type pendingIO struct {
+	probes    [][]byte // probe query packets.
+	announces [][]byte // announcement packets.
+	renames   []renameEvent
+}
+
+type renameEvent struct {
+	oldName string
+	newName string
+	isHost  bool
+}
+
+// probeManager orchestrates probing, announcing, and conflict detection
+// for all names owned by a server. It runs a single event-loop goroutine.
+type probeManager struct {
+	mu       sync.RWMutex
+	sessions []*probeSession
+
+	questionWriter questionWriter
+	answerWriter   answerWriter
+	log            logging.LeveledLogger
+	logName        string
+	ttl            uint32
+
+	// Injected dependencies for deterministic testing (PR #266 pattern).
+	now       func() time.Time
+	newTimer  func(time.Duration) probeTimer
+	randFloat func() float64
+
+	conflictHandler func(ConflictEvent) ConflictAction
+	onRenamed       func(oldName, newName string, isHost bool)
+
+	inbound chan *dnsmessage.Message
+	ready   chan struct{} // closed when initial probing completes.
+	done    chan struct{} // closed when run() exits.
+}
+
+func newProbeManager(
+	questionWriter questionWriter,
+	answerWriter answerWriter,
+	log logging.LeveledLogger,
+	logName string,
+	ttl uint32,
+	conflictHandler func(ConflictEvent) ConflictAction,
+	onRenamed func(oldName, newName string, isHost bool),
+) *probeManager {
+	return &probeManager{
+		questionWriter:  questionWriter,
+		answerWriter:    answerWriter,
+		log:             log,
+		logName:         logName,
+		ttl:             ttl,
+		conflictHandler: conflictHandler,
+		onRenamed:       onRenamed,
+		now:             time.Now,
+		newTimer:        newRealTimer,
+		randFloat:       rand.Float64, //nolint:gosec
+		inbound:         make(chan *dnsmessage.Message, 64),
+		ready:           make(chan struct{}),
+		done:            make(chan struct{}),
+	}
+}
+
+// addSession registers a name for probing. Must be called before run().
+func (m *probeManager) addSession(name string, records []dnsmessage.Resource, isHost bool) {
+	delay := time.Duration(m.randFloat() * float64(probeDelay))
+
+	m.sessions = append(m.sessions, &probeSession{
+		name:      name,
+		records:   records,
+		isHost:    isHost,
+		state:     probeStateDelay,
+		nextEvent: m.now().Add(delay),
+	})
+}
+
+// isProbing reports whether the given name is currently being probed
+// (not yet established). Safe to call from any goroutine.
+func (m *probeManager) isProbing(name string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	lower := strings.ToLower(name)
+	for _, s := range m.sessions {
+		if strings.ToLower(s.name) == lower && s.state != probeStateEstablished && s.state != probeStateStopped {
+			return true
+		}
+	}
+
+	return false
+}
+
+// handleMessage feeds an incoming DNS message to the probe manager for
+// conflict detection. Called from readLoop goroutines. Blocks until the
+// message is accepted or the event loop has exited.
+func (m *probeManager) handleMessage(msg *dnsmessage.Message) {
+	select {
+	case m.inbound <- msg:
+	case <-m.done:
+	}
+}
+
+// run is the event loop. It processes timer ticks and inbound messages
+// until the closed channel is signaled. Call in a goroutine.
+//
+//nolint:gocognit,gocyclo,cyclop
+func (m *probeManager) run(closed <-chan any) {
+	defer close(m.done)
+
+	if len(m.sessions) == 0 {
+		close(m.ready)
+
+		return
+	}
+
+	readyClosed := false
+	signalReady := func() {
+		if readyClosed {
+			return
+		}
+
+		m.mu.RLock()
+		all := m.allDone()
+		m.mu.RUnlock()
+
+		if all {
+			close(m.ready)
+			readyClosed = true
+		}
+	}
+
+	for {
+		// Process any overdue events (state under lock, I/O after).
+		pio := m.processOverdue()
+		m.executeIO(pio)
+		signalReady()
+
+		m.mu.RLock()
+		dur := m.durationToNext()
+		m.mu.RUnlock()
+
+		if dur < 0 {
+			// No pending timer events, wait for messages or close.
+			select {
+			case msg := <-m.inbound:
+				m.mu.Lock()
+				m.processMessage(msg)
+				m.mu.Unlock()
+				signalReady()
+			case <-closed:
+				if !readyClosed {
+					close(m.ready)
+				}
+
+				return
+			}
+
+			continue
+		}
+
+		timer := m.newTimer(dur)
+
+		select {
+		case <-timer.Chan():
+			timer.Stop()
+			// Will process overdue on next iteration.
+		case msg := <-m.inbound:
+			timer.Stop()
+			m.mu.Lock()
+			m.processMessage(msg)
+			m.mu.Unlock()
+			signalReady()
+		case <-closed:
+			timer.Stop()
+			if !readyClosed {
+				close(m.ready)
+			}
+
+			return
+		}
+	}
+}
+
+// allDone reports whether all sessions are established or stopped.
+// Caller must hold at least mu.RLock.
+func (m *probeManager) allDone() bool {
+	for _, s := range m.sessions {
+		if s.state != probeStateEstablished && s.state != probeStateStopped {
+			return false
+		}
+	}
+
+	return true
+}
+
+// durationToNext returns the duration until the next timer event,
+// or -1 if there are no pending events. Caller must hold mu.RLock.
+func (m *probeManager) durationToNext() time.Duration {
+	now := m.now()
+	earliest := time.Duration(-1)
+
+	for _, s := range m.sessions {
+		if s.state == probeStateEstablished || s.state == probeStateStopped {
+			continue
+		}
+
+		d := s.nextEvent.Sub(now)
+		if d < 0 {
+			d = 0
+		}
+
+		if earliest < 0 || d < earliest {
+			earliest = d
+		}
+	}
+
+	return earliest
+}
+
+// processOverdue advances sessions under the lock and returns pending I/O
+// to be executed without the lock.
+func (m *probeManager) processOverdue() pendingIO {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := m.now()
+	var pio pendingIO
+
+	for _, sess := range m.sessions {
+		if sess.state == probeStateStopped {
+			continue
+		}
+
+		if sess.conflict {
+			m.handleConflictForSession(sess, now, &pio)
+
+			continue
+		}
+
+		if sess.tiebreakDefer {
+			m.handleTiebreakDefer(sess, now)
+
+			continue
+		}
+
+		if sess.state == probeStateEstablished {
+			continue
+		}
+
+		if now.Before(sess.nextEvent) {
+			continue
+		}
+
+		m.stepSession(sess, now, &pio)
+	}
+
+	return pio
+}
+
+// executeIO sends all collected packets and fires rename callbacks
+// without holding the lock.
+func (m *probeManager) executeIO(pio pendingIO) {
+	for _, raw := range pio.probes {
+		m.questionWriter.writeQuestion(raw)
+	}
+
+	for _, raw := range pio.announces {
+		m.answerWriter.writeAnswer(-1, raw, false, false, nil)
+	}
+
+	for _, re := range pio.renames {
+		if m.onRenamed != nil {
+			m.onRenamed(re.oldName, re.newName, re.isHost)
+		}
+	}
+}
+
+// stepSession advances a session by one step in the state machine.
+// Caller must hold mu.Lock.
+func (m *probeManager) stepSession(sess *probeSession, now time.Time, pio *pendingIO) {
+	switch sess.state {
+	case probeStateDelay:
+		sess.state = probeStateProbing
+		m.enqueueProbe(sess, pio)
+		sess.probesSent++
+		sess.nextEvent = now.Add(probeInterval)
+
+	case probeStateProbing:
+		if sess.probesSent < probeCount {
+			m.enqueueProbe(sess, pio)
+			sess.probesSent++
+			sess.nextEvent = now.Add(probeInterval)
+		} else {
+			sess.state = probeStateAnnouncing
+			m.enqueueAnnounce(sess, pio)
+			sess.announcesSent++
+			sess.nextEvent = now.Add(announceInterval)
+		}
+
+	case probeStateAnnouncing:
+		m.enqueueAnnounce(sess, pio)
+		sess.announcesSent++
+
+		if sess.announcesSent < announceCount {
+			sess.nextEvent = now.Add(announceInterval)
+		} else {
+			sess.state = probeStateEstablished
+			m.log.Infof("[%s] probe: %s established", m.logName, sess.name)
+		}
+
+	case probeStateEstablished, probeStateStopped:
+		// No-op.
+	}
+}
+
+// handleTiebreakDefer processes a simultaneous probe tiebreak loss (§8.2).
+// The session waits 1 second and then re-probes with the same name. No rename
+// occurs — the 1s delay guards against stale packets on the network.
+// Caller must hold mu.Lock.
+func (m *probeManager) handleTiebreakDefer(sess *probeSession, now time.Time) {
+	sess.tiebreakDefer = false
+	sess.state = probeStateDelay
+	sess.probesSent = 0
+	sess.announcesSent = 0
+	sess.nextEvent = now.Add(time.Second)
+	m.log.Infof("[%s] probe: tiebreak loss for %s, re-probing in 1s", m.logName, sess.name)
+}
+
+// handleConflictForSession processes a naming conflict.
+// Caller must hold mu.Lock.
+//
+//nolint:cyclop
+func (m *probeManager) handleConflictForSession(sess *probeSession, now time.Time, pio *pendingIO) {
+	sess.conflict = false
+	sess.tiebreakDefer = false
+	sess.conflictCount++
+
+	// Track rate limiting.
+	sess.conflictTimes = append(sess.conflictTimes, now)
+	if sess.firstConflict.IsZero() {
+		sess.firstConflict = now
+	}
+
+	m.log.Warnf("[%s] probe: conflict #%d for %s", m.logName, sess.conflictCount, sess.name)
+
+	// Give up after sustained conflicts.
+	if now.Sub(sess.firstConflict) > conflictGiveUp && sess.conflictCount > conflictRateLimit {
+		m.log.Errorf("[%s] probe: giving up on %s after %d conflicts", m.logName, sess.name, sess.conflictCount)
+		sess.state = probeStateStopped
+
+		return
+	}
+
+	// Ask user for rename action.
+	action := m.resolveConflict(sess)
+	if action.Stop {
+		m.log.Infof("[%s] probe: user stopped probing for %s", m.logName, sess.name)
+		sess.state = probeStateStopped
+
+		return
+	}
+
+	// Determine new name.
+	oldName := sess.name
+	newName := action.Rename
+
+	if newName == "" {
+		newName = defaultRename(sess.name, sess.conflictCount, sess.isHost)
+	}
+
+	m.log.Infof("[%s] probe: renaming %s -> %s", m.logName, oldName, newName)
+
+	// Update session records with new name.
+	m.renameSession(sess, newName)
+
+	// Queue server notification (executed without lock).
+	pio.renames = append(pio.renames, renameEvent{
+		oldName: oldName,
+		newName: newName,
+		isHost:  sess.isHost,
+	})
+
+	// Rate-limit backoff.
+	delay := probeDelay
+	backoff := m.shouldBackoff(sess, now)
+
+	if backoff > 0 {
+		delay += backoff
+	}
+
+	sess.state = probeStateDelay
+	sess.probesSent = 0
+	sess.announcesSent = 0
+	sess.nextEvent = now.Add(delay)
+}
+
+// resolveConflict calls the user conflict handler or returns an empty action.
+func (m *probeManager) resolveConflict(sess *probeSession) ConflictAction {
+	if m.conflictHandler == nil {
+		return ConflictAction{}
+	}
+
+	return m.conflictHandler(ConflictEvent{
+		Name:  sess.name,
+		Count: sess.conflictCount,
+		Host:  sess.isHost,
+	})
+}
+
+// shouldBackoff checks rate limiting: 15 conflicts in 10s → 5s backoff.
+func (m *probeManager) shouldBackoff(sess *probeSession, now time.Time) time.Duration {
+	cutoff := now.Add(-conflictRateWindow)
+	valid := 0
+
+	for _, t := range sess.conflictTimes {
+		if !t.Before(cutoff) {
+			sess.conflictTimes[valid] = t
+			valid++
+		}
+	}
+
+	sess.conflictTimes = sess.conflictTimes[:valid]
+
+	if len(sess.conflictTimes) >= conflictRateLimit {
+		return conflictBackoff
+	}
+
+	return 0
+}
+
+// renameSession updates the session's name and rewrites all record headers.
+func (m *probeManager) renameSession(sess *probeSession, newName string) {
+	sess.name = newName
+
+	newDNSName, err := dnsmessage.NewName(newName)
+	if err != nil {
+		m.log.Warnf("[%s] probe: failed to create DNS name %s: %v", m.logName, newName, err)
+
+		return
+	}
+
+	for i := range sess.records {
+		sess.records[i].Header.Name = newDNSName
+	}
+}
+
+// enqueueProbe builds a probe query and appends it to the pending I/O.
+func (m *probeManager) enqueueProbe(sess *probeSession, pio *pendingIO) {
+	raw, err := buildProbeQuery(sess.name, sess.records)
+	if err != nil {
+		m.log.Warnf("[%s] probe: failed to build probe for %s: %v", m.logName, sess.name, err)
+
+		return
+	}
+
+	m.log.Debugf("[%s] probe: queueing probe %d/%d for %s", m.logName, sess.probesSent+1, probeCount, sess.name)
+	pio.probes = append(pio.probes, raw)
+}
+
+// enqueueAnnounce builds an announcement and appends it to the pending I/O.
+func (m *probeManager) enqueueAnnounce(sess *probeSession, pio *pendingIO) {
+	raw, err := buildAnnouncement(sess.records)
+	if err != nil {
+		m.log.Warnf("[%s] probe: failed to build announce for %s: %v", m.logName, sess.name, err)
+
+		return
+	}
+
+	m.log.Debugf("[%s] probe: queueing announce %d/%d for %s", m.logName, sess.announcesSent+1, announceCount, sess.name)
+	pio.announces = append(pio.announces, raw)
+}
+
+// processMessage handles an inbound DNS message for conflict detection.
+// Caller must hold mu.Lock.
+func (m *probeManager) processMessage(msg *dnsmessage.Message) {
+	if msg.Header.Response {
+		m.processResponse(msg)
+	} else {
+		m.processProbe(msg)
+	}
+}
+
+// processResponse checks response answers against probed/established names.
+// An answer matching our name during probing or with conflicting rdata during
+// established state triggers a conflict.
+// Caller must hold mu.Lock.
+func (m *probeManager) processResponse(msg *dnsmessage.Message) {
+	// §9: check "any of the Resource Record Sections" for conflicts.
+	allRecords := msg.Answers
+	allRecords = append(allRecords, msg.Authorities...)
+	allRecords = append(allRecords, msg.Additionals...)
+
+	for _, sess := range m.sessions {
+		if sess.state == probeStateStopped {
+			continue
+		}
+
+		for idx := range allRecords {
+			rec := &allRecords[idx]
+			if !strings.EqualFold(rec.Header.Name.String(), sess.name) {
+				continue
+			}
+
+			switch sess.state {
+			case probeStateDelay:
+				// Responses before the first probe MUST be silently
+				// ignored (§8.1 — stale probe guard).
+			case probeStateProbing:
+				// Any record for our name during probing = conflict (§8.1).
+				sess.conflict = true
+			case probeStateAnnouncing, probeStateEstablished:
+				// Record with different rdata for our unique record = conflict.
+				if m.isConflictingRData(sess, rec) {
+					sess.conflict = true
+				}
+			case probeStateStopped:
+				// No-op.
+			}
+		}
+	}
+}
+
+// processProbe handles incoming probes (questions with authority section)
+// for simultaneous probe tiebreaking (§8.2).
+// Caller must hold mu.Lock.
+func (m *probeManager) processProbe(msg *dnsmessage.Message) {
+	if len(msg.Authorities) == 0 {
+		return
+	}
+
+	for _, sess := range m.sessions {
+		if sess.state != probeStateProbing {
+			continue
+		}
+
+		for _, q := range msg.Questions {
+			if !strings.EqualFold(q.Name.String(), sess.name) {
+				continue
+			}
+
+			m.tiebreakQuestion(sess, q, msg.Authorities)
+		}
+	}
+}
+
+// tiebreakQuestion performs simultaneous probe tiebreaking (section 8.2) for a
+// single question against the session's proposed records.
+// Caller must hold mu.Lock.
+func (m *probeManager) tiebreakQuestion(sess *probeSession, _ dnsmessage.Question, authorities []dnsmessage.Resource) {
+	// Collect their authority records for our name.
+	var theirs []dnsmessage.Resource
+	for _, auth := range authorities {
+		if strings.EqualFold(auth.Header.Name.String(), sess.name) {
+			theirs = append(theirs, auth)
+		}
+	}
+
+	if len(theirs) == 0 {
+		return
+	}
+
+	// Tiebreak: compare our records vs theirs.
+	result := lexicographicCompare(sess.records, theirs)
+	if result < 0 {
+		// We lose -- defer to them.
+		sess.tiebreakDefer = true
+	}
+	// If we win (result > 0) or tie (result == 0), continue probing.
+}
+
+// isConflictingRData checks whether an answer has rdata we do not own for
+// the same name and record type. A conflict exists only when the answer's
+// rdata matches none of our records of that type.
+func (m *probeManager) isConflictingRData(sess *probeSession, answer *dnsmessage.Resource) bool {
+	ansType := answer.Header.Type
+	theirs := packRData(answer.Body)
+	hasType := false
+
+	for _, rec := range sess.records {
+		if rec.Header.Type != ansType {
+			continue
+		}
+
+		hasType = true
+
+		if bytes.Equal(packRData(rec.Body), theirs) {
+			return false // matches one of ours.
+		}
+	}
+
+	return hasType // conflict only if we have this type but no match.
+}
+
+// buildProbeQuery creates a probe query message (§8.1):
+//
+//	Questions:   [Name=target, Type=ANY(255), Class=IN|QU]
+//	Authorities: proposed records
+func buildProbeQuery(name string, records []dnsmessage.Resource) ([]byte, error) {
+	dnsName, err := dnsmessage.NewName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	msg := dnsmessage.Message{
+		Questions: []dnsmessage.Question{{
+			Name:  dnsName,
+			Type:  typeANY,
+			Class: dnsmessage.ClassINET | qClassUnicastResponse,
+		}},
+		Authorities: records,
+	}
+
+	return msg.Pack()
+}
+
+// buildAnnouncement creates an unsolicited announcement (§8.3).
+// Unique records get the cache-flush bit; PTR records (shared) do not.
+func buildAnnouncement(records []dnsmessage.Resource) ([]byte, error) {
+	answers := make([]dnsmessage.Resource, len(records))
+	copy(answers, records)
+
+	for i := range answers {
+		// PTR records are shared — no cache-flush bit.
+		if answers[i].Header.Type == dnsmessage.TypePTR {
+			continue
+		}
+
+		answers[i].Header.Class |= rrClassCacheFlush
+	}
+
+	msg := dnsmessage.Message{
+		Header: dnsmessage.Header{
+			Response:      true,
+			Authoritative: true,
+		},
+		Answers: answers,
+	}
+
+	return msg.Pack()
+}
+
+// lexicographicCompare compares two sets of resource records using the
+// algorithm from RFC 6762 §8.2 for simultaneous probe tiebreaking.
+//
+// Each set is sorted by class, then type, then rdata. Records are compared
+// pairwise; the first difference decides the outcome.
+//
+// Returns -1 if ours < theirs, 0 if equal, +1 if ours > theirs.
+func lexicographicCompare(ours, theirs []dnsmessage.Resource) int {
+	// Work on copies to avoid mutating the originals.
+	oCopy := make([]dnsmessage.Resource, len(ours))
+	copy(oCopy, ours)
+	sortResources(oCopy)
+
+	tCopy := make([]dnsmessage.Resource, len(theirs))
+	copy(tCopy, theirs)
+	sortResources(tCopy)
+
+	n := len(oCopy)
+	if len(tCopy) < n {
+		n = len(tCopy)
+	}
+
+	for i := 0; i < n; i++ {
+		if c := compareResource(oCopy[i], tCopy[i]); c != 0 {
+			return c
+		}
+	}
+
+	return cmp.Compare(len(oCopy), len(tCopy))
+}
+
+// sortResources sorts records by class, then type, then rdata (§8.2).
+func sortResources(rs []dnsmessage.Resource) {
+	for i := 1; i < len(rs); i++ {
+		for j := i; j > 0 && compareResource(rs[j-1], rs[j]) > 0; j-- {
+			rs[j-1], rs[j] = rs[j], rs[j-1]
+		}
+	}
+}
+
+// compareResource compares two resource records: class (mask cache-flush),
+// then type, then raw rdata.
+func compareResource(resA, resB dnsmessage.Resource) int {
+	// Compare class without cache-flush bit.
+	aClass := resA.Header.Class &^ rrClassCacheFlush
+	bClass := resB.Header.Class &^ rrClassCacheFlush
+
+	if c := cmp.Compare(aClass, bClass); c != 0 {
+		return c
+	}
+
+	if c := cmp.Compare(resA.Header.Type, resB.Header.Type); c != 0 {
+		return c
+	}
+
+	aData := packRData(resA.Body)
+	bData := packRData(resB.Body)
+
+	return bytes.Compare(aData, bData)
+}
+
+// packRData serializes the rdata portion of a resource record body into
+// wire-format bytes for lexicographic comparison.
+//
+//nolint:cyclop
+func packRData(body dnsmessage.ResourceBody) []byte {
+	if body == nil {
+		return nil
+	}
+
+	switch rec := body.(type) {
+	case *dnsmessage.AResource:
+		return rec.A[:]
+	case *dnsmessage.AAAAResource:
+		return rec.AAAA[:]
+	case *dnsmessage.SRVResource:
+		buf := make([]byte, 0, 6+255)
+		buf = append(buf, 0, 0, 0, 0, 0, 0)
+		binary.BigEndian.PutUint16(buf[0:2], rec.Priority)
+		binary.BigEndian.PutUint16(buf[2:4], rec.Weight)
+		binary.BigEndian.PutUint16(buf[4:6], rec.Port)
+
+		return append(buf, packDNSName(rec.Target)...)
+	case *dnsmessage.TXTResource:
+		var buf []byte
+		for _, txt := range rec.TXT {
+			buf = append(buf, byte(len(txt)))
+			buf = append(buf, txt...)
+		}
+
+		return buf
+	case *dnsmessage.PTRResource:
+		return packDNSName(rec.PTR)
+	default:
+		return nil
+	}
+}
+
+// packDNSName serializes a DNS name into wire-format bytes (sequence of
+// length-prefixed labels ending with a zero byte).
+func packDNSName(n dnsmessage.Name) []byte {
+	s := n.String()
+	if s == "" || s == "." {
+		return []byte{0}
+	}
+
+	s = strings.TrimSuffix(s, ".")
+	labels := strings.Split(s, ".")
+
+	var buf []byte
+	for _, label := range labels {
+		buf = append(buf, byte(len(label)))
+		buf = append(buf, label...)
+	}
+
+	return append(buf, 0)
+}
+
+// defaultRename generates a conflict-avoidance name per RFC 6762 §9.
+//
+// Hostnames: "myhost.local." → "myhost-2.local."
+// Service instances: "My Service._http._tcp.local." → "My Service (2)._http._tcp.local.".
+func defaultRename(fqdn string, conflictCount int, isHost bool) string {
+	suffix := conflictCount + 1
+
+	if isHost {
+		return defaultRenameHost(fqdn, suffix)
+	}
+
+	return defaultRenameServiceInstance(fqdn, suffix)
+}
+
+func defaultRenameHost(fqdn string, num int) string {
+	// "myhost.local." → split into ["myhost", "local."]
+	idx := strings.IndexByte(fqdn, '.')
+	if idx < 0 {
+		return fmt.Sprintf("%s-%d", fqdn, num)
+	}
+
+	host := fqdn[:idx]
+
+	// Strip previous rename suffix: "myhost-2" → "myhost".
+	if dashIdx := strings.LastIndexByte(host, '-'); dashIdx >= 0 {
+		candidate := host[dashIdx+1:]
+		allDigit := true
+
+		for _, c := range candidate {
+			if c < '0' || c > '9' {
+				allDigit = false
+
+				break
+			}
+		}
+
+		if allDigit && len(candidate) > 0 {
+			host = host[:dashIdx]
+		}
+	}
+
+	return fmt.Sprintf("%s-%d%s", host, num, fqdn[idx:])
+}
+
+func defaultRenameServiceInstance(fqdn string, num int) string {
+	// Service instance FQDN: "My\.Service._http._tcp.local."
+	// The instance part is everything before the service type (first
+	// unescaped underscore label).
+	//
+	// Find the service type boundary: first label starting with '_'.
+	parts := strings.SplitN(fqdn, "._", 2)
+	if len(parts) < 2 {
+		return fmt.Sprintf("%s (%d)", fqdn, num)
+	}
+
+	instance := stripServiceSuffix(parts[0])
+
+	return fmt.Sprintf("%s (%d)._%s", instance, num, parts[1])
+}
+
+// stripServiceSuffix removes a previous " (N)" rename suffix from the
+// service instance name, e.g. "My Service (2)" becomes "My Service".
+func stripServiceSuffix(instance string) string {
+	parenIdx := strings.LastIndex(instance, " (")
+	if parenIdx < 0 {
+		return instance
+	}
+
+	candidate := instance[parenIdx+2:]
+	if !strings.HasSuffix(candidate, ")") {
+		return instance
+	}
+
+	inner := candidate[:len(candidate)-1]
+	if len(inner) == 0 {
+		return instance
+	}
+
+	for _, c := range inner {
+		if c < '0' || c > '9' {
+			return instance
+		}
+	}
+
+	return instance[:parenIdx]
+}

--- a/probe.go
+++ b/probe.go
@@ -111,9 +111,11 @@ const (
 
 // probeSession tracks the probing lifecycle for a single DNS name.
 type probeSession struct {
-	name    string                // FQDN being probed (e.g. "myhost.local.").
-	records []dnsmessage.Resource // proposed records (authority / announce).
-	isHost  bool                  // hostname vs service instance.
+	name     string                // FQDN being probed (e.g. "myhost.local.").
+	baseName string                // original FQDN; default renames derive from it.
+	records  []dnsmessage.Resource // proposed unique records (probe authority / announce).
+	shared   []dnsmessage.Resource // shared records (e.g. PTR): announced, never probed.
+	isHost   bool                  // hostname vs service instance.
 
 	state         probeState
 	probesSent    int
@@ -123,7 +125,8 @@ type probeSession struct {
 	conflictCount int
 	conflictTimes []time.Time // for rate limiting.
 	firstConflict time.Time   // for give-up timeout.
-	conflict      bool        // flag set by message handler.
+	conflict      bool        // conflict during probing: rename (§8.1).
+	reProbe       bool        // conflict after probing: re-probe same name (§9).
 	tiebreakDefer bool        // flag set by simultaneous probe handler.
 }
 
@@ -151,7 +154,6 @@ type probeManager struct {
 	answerWriter   answerWriter
 	log            logging.LeveledLogger
 	logName        string
-	ttl            uint32
 
 	// Injected dependencies for deterministic testing (PR #266 pattern).
 	now       func() time.Time
@@ -171,7 +173,6 @@ func newProbeManager(
 	answerWriter answerWriter,
 	log logging.LeveledLogger,
 	logName string,
-	ttl uint32,
 	conflictHandler func(ConflictEvent) ConflictAction,
 	onRenamed func(oldName, newName string, isHost bool),
 ) *probeManager {
@@ -180,7 +181,6 @@ func newProbeManager(
 		answerWriter:    answerWriter,
 		log:             log,
 		logName:         logName,
-		ttl:             ttl,
 		conflictHandler: conflictHandler,
 		onRenamed:       onRenamed,
 		now:             time.Now,
@@ -193,12 +193,18 @@ func newProbeManager(
 }
 
 // addSession registers a name for probing. Must be called before run().
-func (m *probeManager) addSession(name string, records []dnsmessage.Resource, isHost bool) {
+// Shared records (e.g. the DNS-SD PTR) are announced alongside the unique
+// records but take no part in probing, tiebreaking, or conflict detection.
+func (m *probeManager) addSession(name string, records []dnsmessage.Resource, isHost bool,
+	shared ...dnsmessage.Resource,
+) {
 	delay := time.Duration(m.randFloat() * float64(probeDelay))
 
 	m.sessions = append(m.sessions, &probeSession{
 		name:      name,
+		baseName:  name,
 		records:   records,
+		shared:    shared,
 		isHost:    isHost,
 		state:     probeStateDelay,
 		nextEvent: m.now().Add(delay),
@@ -279,10 +285,8 @@ func (m *probeManager) run(closed <-chan any) {
 				m.mu.Unlock()
 				signalReady()
 			case <-closed:
-				if !readyClosed {
-					close(m.ready)
-				}
-
+				// Leave ready unclosed: WaitReady reports the closed
+				// connection via its own closed-channel arm.
 				return
 			}
 
@@ -303,9 +307,6 @@ func (m *probeManager) run(closed <-chan any) {
 			signalReady()
 		case <-closed:
 			timer.Stop()
-			if !readyClosed {
-				close(m.ready)
-			}
 
 			return
 		}
@@ -361,6 +362,12 @@ func (m *probeManager) processOverdue() pendingIO {
 
 		if sess.conflict {
 			m.handleConflictForSession(sess, now, &pio)
+
+			continue
+		}
+
+		if sess.reProbe {
+			m.handleReProbe(sess, now)
 
 			continue
 		}
@@ -454,12 +461,12 @@ func (m *probeManager) handleTiebreakDefer(sess *probeSession, now time.Time) {
 	m.log.Infof("[%s] probe: tiebreak loss for %s, re-probing in 1s", m.logName, sess.name)
 }
 
-// handleConflictForSession processes a naming conflict.
+// recordConflict updates conflict accounting (count, rate-limit window,
+// give-up timeout) and reports whether the session should give up.
 // Caller must hold mu.Lock.
-//
-//nolint:cyclop
-func (m *probeManager) handleConflictForSession(sess *probeSession, now time.Time, pio *pendingIO) {
+func (m *probeManager) recordConflict(sess *probeSession, now time.Time) (giveUp bool) {
 	sess.conflict = false
+	sess.reProbe = false
 	sess.tiebreakDefer = false
 	sess.conflictCount++
 
@@ -476,6 +483,35 @@ func (m *probeManager) handleConflictForSession(sess *probeSession, now time.Tim
 		m.log.Errorf("[%s] probe: giving up on %s after %d conflicts", m.logName, sess.name, sess.conflictCount)
 		sess.state = probeStateStopped
 
+		return true
+	}
+
+	return false
+}
+
+// handleReProbe processes a conflict detected after probing completed
+// (§9): the record resets to probing state with the SAME name. A rename
+// happens only if the subsequent probing also conflicts. The §8.1 rate
+// limit applies across both kinds of conflict.
+// Caller must hold mu.Lock.
+func (m *probeManager) handleReProbe(sess *probeSession, now time.Time) {
+	if m.recordConflict(sess, now) {
+		return
+	}
+
+	m.log.Infof("[%s] probe: re-probing %s after post-probing conflict", m.logName, sess.name)
+
+	sess.state = probeStateDelay
+	sess.probesSent = 0
+	sess.announcesSent = 0
+	sess.nextEvent = now.Add(probeDelay + m.shouldBackoff(sess, now))
+}
+
+// handleConflictForSession processes a naming conflict detected during
+// probing (§8.1): the session renames and starts over.
+// Caller must hold mu.Lock.
+func (m *probeManager) handleConflictForSession(sess *probeSession, now time.Time, pio *pendingIO) {
+	if m.recordConflict(sess, now) {
 		return
 	}
 
@@ -488,12 +524,16 @@ func (m *probeManager) handleConflictForSession(sess *probeSession, now time.Tim
 		return
 	}
 
-	// Determine new name.
+	// Determine new name. Defaults derive from the original base name so
+	// repeated conflicts yield "base-2", "base-3", ... without suffix
+	// stripping. A custom rename becomes the new base.
 	oldName := sess.name
 	newName := action.Rename
 
 	if newName == "" {
-		newName = defaultRename(sess.name, sess.conflictCount, sess.isHost)
+		newName = defaultRename(sess.baseName, sess.conflictCount, sess.isHost)
+	} else {
+		sess.baseName = newName
 	}
 
 	m.log.Infof("[%s] probe: renaming %s -> %s", m.logName, oldName, newName)
@@ -556,7 +596,9 @@ func (m *probeManager) shouldBackoff(sess *probeSession, now time.Time) time.Dur
 	return 0
 }
 
-// renameSession updates the session's name and rewrites all record headers.
+// renameSession updates the session's name, rewrites the unique record
+// headers, and retargets shared PTR records (whose header is the service
+// type, not the renamed instance).
 func (m *probeManager) renameSession(sess *probeSession, newName string) {
 	sess.name = newName
 
@@ -569,6 +611,12 @@ func (m *probeManager) renameSession(sess *probeSession, newName string) {
 
 	for i := range sess.records {
 		sess.records[i].Header.Name = newDNSName
+	}
+
+	for i := range sess.shared {
+		if ptr, ok := sess.shared[i].Body.(*dnsmessage.PTRResource); ok {
+			ptr.PTR = newDNSName
+		}
 	}
 }
 
@@ -587,7 +635,7 @@ func (m *probeManager) enqueueProbe(sess *probeSession, pio *pendingIO) {
 
 // enqueueAnnounce builds an announcement and appends it to the pending I/O.
 func (m *probeManager) enqueueAnnounce(sess *probeSession, pio *pendingIO) {
-	raw, err := buildAnnouncement(sess.records)
+	raw, err := buildAnnouncement(sess.records, sess.shared)
 	if err != nil {
 		m.log.Warnf("[%s] probe: failed to build announce for %s: %v", m.logName, sess.name, err)
 
@@ -609,42 +657,49 @@ func (m *probeManager) processMessage(msg *dnsmessage.Message) {
 }
 
 // processResponse checks response answers against probed/established names.
-// An answer matching our name during probing or with conflicting rdata during
-// established state triggers a conflict.
+// An answer matching our name during probing triggers a rename (§8.1); one
+// with conflicting rdata after probing triggers a re-probe (§9).
 // Caller must hold mu.Lock.
 func (m *probeManager) processResponse(msg *dnsmessage.Message) {
-	// §9: check "any of the Resource Record Sections" for conflicts.
-	allRecords := msg.Answers
-	allRecords = append(allRecords, msg.Authorities...)
-	allRecords = append(allRecords, msg.Additionals...)
-
 	for _, sess := range m.sessions {
 		if sess.state == probeStateStopped {
 			continue
 		}
 
-		for idx := range allRecords {
-			rec := &allRecords[idx]
-			if !strings.EqualFold(rec.Header.Name.String(), sess.name) {
-				continue
-			}
-
-			switch sess.state {
-			case probeStateDelay:
-				// Responses before the first probe MUST be silently
-				// ignored (§8.1 — stale probe guard).
-			case probeStateProbing:
-				// Any record for our name during probing = conflict (§8.1).
-				sess.conflict = true
-			case probeStateAnnouncing, probeStateEstablished:
-				// Record with different rdata for our unique record = conflict.
-				if m.isConflictingRData(sess, rec) {
-					sess.conflict = true
-				}
-			case probeStateStopped:
-				// No-op.
+		// §9: check "any of the Resource Record Sections" for conflicts.
+		// Iterate the sections in place; concatenating would alias the
+		// message shared with the question/client handlers.
+		for _, section := range [][]dnsmessage.Resource{msg.Answers, msg.Authorities, msg.Additionals} {
+			for idx := range section {
+				m.checkRecordConflict(sess, &section[idx])
 			}
 		}
+	}
+}
+
+// checkRecordConflict flags a session conflict if the record clashes with
+// the session's name in its current state.
+// Caller must hold mu.Lock.
+func (m *probeManager) checkRecordConflict(sess *probeSession, rec *dnsmessage.Resource) {
+	if !strings.EqualFold(rec.Header.Name.String(), sess.name) {
+		return
+	}
+
+	switch sess.state {
+	case probeStateDelay:
+		// Responses before the first probe MUST be silently
+		// ignored (§8.1 — stale probe guard).
+	case probeStateProbing:
+		// Any record for our name during probing = conflict (§8.1).
+		sess.conflict = true
+	case probeStateAnnouncing, probeStateEstablished:
+		// Record with different rdata for our unique record after
+		// probing completed = re-probe the same name (§9).
+		if m.isConflictingRData(sess, rec) {
+			sess.reProbe = true
+		}
+	case probeStateStopped:
+		// No-op.
 	}
 }
 
@@ -666,7 +721,7 @@ func (m *probeManager) processProbe(msg *dnsmessage.Message) {
 				continue
 			}
 
-			m.tiebreakQuestion(sess, q, msg.Authorities)
+			m.tiebreakQuestion(sess, msg.Authorities)
 		}
 	}
 }
@@ -674,7 +729,7 @@ func (m *probeManager) processProbe(msg *dnsmessage.Message) {
 // tiebreakQuestion performs simultaneous probe tiebreaking (section 8.2) for a
 // single question against the session's proposed records.
 // Caller must hold mu.Lock.
-func (m *probeManager) tiebreakQuestion(sess *probeSession, _ dnsmessage.Question, authorities []dnsmessage.Resource) {
+func (m *probeManager) tiebreakQuestion(sess *probeSession, authorities []dnsmessage.Resource) {
 	// Collect their authority records for our name.
 	var theirs []dnsmessage.Resource
 	for _, auth := range authorities {
@@ -741,20 +796,18 @@ func buildProbeQuery(name string, records []dnsmessage.Resource) ([]byte, error)
 	return msg.Pack()
 }
 
-// buildAnnouncement creates an unsolicited announcement (§8.3).
-// Unique records get the cache-flush bit; PTR records (shared) do not.
-func buildAnnouncement(records []dnsmessage.Resource) ([]byte, error) {
-	answers := make([]dnsmessage.Resource, len(records))
-	copy(answers, records)
+// buildAnnouncement creates an unsolicited announcement (§8.3) containing
+// all of the session's records: unique records get the cache-flush bit,
+// shared records (e.g. the DNS-SD PTR) do not.
+func buildAnnouncement(unique, shared []dnsmessage.Resource) ([]byte, error) {
+	answers := make([]dnsmessage.Resource, 0, len(unique)+len(shared))
+	answers = append(answers, unique...)
 
 	for i := range answers {
-		// PTR records are shared — no cache-flush bit.
-		if answers[i].Header.Type == dnsmessage.TypePTR {
-			continue
-		}
-
 		answers[i].Header.Class |= rrClassCacheFlush
 	}
+
+	answers = append(answers, shared...)
 
 	msg := dnsmessage.Message{
 		Header: dnsmessage.Header{
@@ -883,17 +936,19 @@ func packDNSName(n dnsmessage.Name) []byte {
 }
 
 // defaultRename generates a conflict-avoidance name per RFC 6762 §9.
+// It always derives from the session's original base name, so user-chosen
+// names that happen to end in "-2" or " (2)" are never mangled.
 //
 // Hostnames: "myhost.local." → "myhost-2.local."
 // Service instances: "My Service._http._tcp.local." → "My Service (2)._http._tcp.local.".
-func defaultRename(fqdn string, conflictCount int, isHost bool) string {
+func defaultRename(baseFQDN string, conflictCount int, isHost bool) string {
 	suffix := conflictCount + 1
 
 	if isHost {
-		return defaultRenameHost(fqdn, suffix)
+		return defaultRenameHost(baseFQDN, suffix)
 	}
 
-	return defaultRenameServiceInstance(fqdn, suffix)
+	return defaultRenameServiceInstance(baseFQDN, suffix)
 }
 
 func defaultRenameHost(fqdn string, num int) string {
@@ -903,68 +958,20 @@ func defaultRenameHost(fqdn string, num int) string {
 		return fmt.Sprintf("%s-%d", fqdn, num)
 	}
 
-	host := fqdn[:idx]
-
-	// Strip previous rename suffix: "myhost-2" → "myhost".
-	if dashIdx := strings.LastIndexByte(host, '-'); dashIdx >= 0 {
-		candidate := host[dashIdx+1:]
-		allDigit := true
-
-		for _, c := range candidate {
-			if c < '0' || c > '9' {
-				allDigit = false
-
-				break
-			}
-		}
-
-		if allDigit && len(candidate) > 0 {
-			host = host[:dashIdx]
-		}
-	}
-
-	return fmt.Sprintf("%s-%d%s", host, num, fqdn[idx:])
+	return fmt.Sprintf("%s-%d%s", fqdn[:idx], num, fqdn[idx:])
 }
 
 func defaultRenameServiceInstance(fqdn string, num int) string {
 	// Service instance FQDN: "My\.Service._http._tcp.local."
 	// The instance part is everything before the service type (first
-	// unescaped underscore label).
-	//
-	// Find the service type boundary: first label starting with '_'.
+	// label starting with '_'). An instance name containing a literal
+	// dot-underscore sequence (escaped "\._") would split early; such
+	// names are pathological and the rename still produces a valid,
+	// unique name.
 	parts := strings.SplitN(fqdn, "._", 2)
 	if len(parts) < 2 {
 		return fmt.Sprintf("%s (%d)", fqdn, num)
 	}
 
-	instance := stripServiceSuffix(parts[0])
-
-	return fmt.Sprintf("%s (%d)._%s", instance, num, parts[1])
-}
-
-// stripServiceSuffix removes a previous " (N)" rename suffix from the
-// service instance name, e.g. "My Service (2)" becomes "My Service".
-func stripServiceSuffix(instance string) string {
-	parenIdx := strings.LastIndex(instance, " (")
-	if parenIdx < 0 {
-		return instance
-	}
-
-	candidate := instance[parenIdx+2:]
-	if !strings.HasSuffix(candidate, ")") {
-		return instance
-	}
-
-	inner := candidate[:len(candidate)-1]
-	if len(inner) == 0 {
-		return instance
-	}
-
-	for _, c := range inner {
-		if c < '0' || c > '9' {
-			return instance
-		}
-	}
-
-	return instance[:parenIdx]
+	return fmt.Sprintf("%s (%d)._%s", parts[0], num, parts[1])
 }

--- a/probe.go
+++ b/probe.go
@@ -49,6 +49,10 @@ const (
 
 	// typeANY is the QTYPE for "ANY" queries (RFC 1035 §3.2.3).
 	typeANY = dnsmessage.TypeALL // 255
+
+	// inboundBufferSize is the capacity of the probe manager's inbound
+	// message channel. Sized to absorb read-loop bursts without blocking.
+	inboundBufferSize = 64
 )
 
 // probeTimer abstracts time.Timer for testability.
@@ -182,7 +186,7 @@ func newProbeManager(
 		now:             time.Now,
 		newTimer:        newRealTimer,
 		randFloat:       rand.Float64, //nolint:gosec
-		inbound:         make(chan *dnsmessage.Message, 64),
+		inbound:         make(chan *dnsmessage.Message, inboundBufferSize),
 		ready:           make(chan struct{}),
 		done:            make(chan struct{}),
 	}

--- a/probe.go
+++ b/probe.go
@@ -786,7 +786,7 @@ func lexicographicCompare(ours, theirs []dnsmessage.Resource) int {
 
 	n := min(len(oCopy), len(tCopy))
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if c := compareResource(oCopy[i], tCopy[i]); c != 0 {
 			return c
 		}

--- a/probe.go
+++ b/probe.go
@@ -335,10 +335,7 @@ func (m *probeManager) durationToNext() time.Duration {
 			continue
 		}
 
-		d := s.nextEvent.Sub(now)
-		if d < 0 {
-			d = 0
-		}
+		d := max(s.nextEvent.Sub(now), 0)
 
 		if earliest < 0 || d < earliest {
 			earliest = d
@@ -787,10 +784,7 @@ func lexicographicCompare(ours, theirs []dnsmessage.Resource) int {
 	copy(tCopy, theirs)
 	sortResources(tCopy)
 
-	n := len(oCopy)
-	if len(tCopy) < n {
-		n = len(tCopy)
-	}
+	n := min(len(oCopy), len(tCopy))
 
 	for i := 0; i < n; i++ {
 		if c := compareResource(oCopy[i], tCopy[i]); c != 0 {
@@ -856,7 +850,7 @@ func packRData(body dnsmessage.ResourceBody) []byte {
 	case *dnsmessage.TXTResource:
 		var buf []byte
 		for _, txt := range rec.TXT {
-			buf = append(buf, byte(len(txt)))
+			buf = append(buf, byte(min(len(txt), 255))) //nolint:gosec // DNS TXT strings are <=255 by wire format
 			buf = append(buf, txt...)
 		}
 
@@ -881,7 +875,7 @@ func packDNSName(n dnsmessage.Name) []byte {
 
 	var buf []byte
 	for _, label := range labels {
-		buf = append(buf, byte(len(label)))
+		buf = append(buf, byte(min(len(label), 63))) //nolint:gosec // DNS labels are <=63 by wire format
 		buf = append(buf, label...)
 	}
 

--- a/probe_test.go
+++ b/probe_test.go
@@ -1,0 +1,1229 @@
+// SPDX-FileCopyrightText: The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package mdns
+
+import (
+	"encoding/binary"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pion/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+// fakeTimer implements probeTimer for deterministic testing.
+type fakeTimer struct {
+	ch      chan time.Time
+	stopped bool
+}
+
+func (t *fakeTimer) Chan() <-chan time.Time { return t.ch }
+
+func (t *fakeTimer) Stop() bool {
+	old := !t.stopped
+	t.stopped = true
+
+	return old
+}
+
+func (t *fakeTimer) fire() { t.ch <- time.Time{} }
+
+// testHarness sets up a probeManager with deterministic time, fake writers,
+// and helpers for driving the event loop.
+type testHarness struct {
+	pm        *probeManager
+	questions [][]byte
+	answers   [][]byte
+	renames   []renameEvent
+	closed    chan any
+	cond      *sync.Cond
+	clock     time.Time
+	timers    []*fakeTimer
+}
+
+func newTestHarness() *testHarness {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	th := &testHarness{
+		closed: make(chan any),
+		clock:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	th.cond = sync.NewCond(&sync.Mutex{})
+
+	qw := &probeTestQuestionWriter{th: th}
+	aw := &probeTestAnswerWriter{th: th}
+
+	th.pm = newProbeManager(qw, aw, log, "test", 120, nil, func(oldName, newName string, isHost bool) {
+		th.cond.L.Lock()
+		th.renames = append(th.renames, renameEvent{oldName: oldName, newName: newName, isHost: isHost})
+		th.cond.L.Unlock()
+		th.cond.Broadcast()
+	})
+	th.pm.now = func() time.Time {
+		th.cond.L.Lock()
+		defer th.cond.L.Unlock()
+
+		return th.clock
+	}
+	th.pm.randFloat = func() float64 { return 0 } // zero delay.
+	th.pm.newTimer = func(d time.Duration) probeTimer {
+		ft := &fakeTimer{ch: make(chan time.Time, 1)}
+		th.cond.L.Lock()
+		th.timers = append(th.timers, ft)
+		th.cond.L.Unlock()
+		th.cond.Broadcast()
+
+		return ft
+	}
+
+	return th
+}
+
+func (th *testHarness) advance(d time.Duration) {
+	th.cond.L.Lock()
+	th.clock = th.clock.Add(d)
+	th.cond.L.Unlock()
+}
+
+func (th *testHarness) lastTimer() *fakeTimer {
+	th.cond.L.Lock()
+	defer th.cond.L.Unlock()
+
+	if len(th.timers) == 0 {
+		return nil
+	}
+
+	return th.timers[len(th.timers)-1]
+}
+
+// await blocks until fn() returns true (checked under cond.L).
+// fn is called while holding cond.L.
+func (th *testHarness) await(fn func() bool) bool {
+	done := make(chan struct{})
+
+	var timedOut atomic.Bool
+
+	go func() {
+		th.cond.L.Lock()
+		defer th.cond.L.Unlock()
+
+		for !fn() && !timedOut.Load() {
+			th.cond.Wait()
+		}
+
+		if fn() {
+			close(done)
+		}
+	}()
+
+	select {
+	case <-done:
+		return true
+	case <-time.After(5 * time.Second):
+		timedOut.Store(true)
+		th.cond.Broadcast()
+
+		return false
+	}
+}
+
+// awaitTimer blocks until at least n timers exist, returns the last one.
+func (th *testHarness) awaitTimer(n int) *fakeTimer {
+	ok := th.await(func() bool { return len(th.timers) >= n })
+	if !ok {
+		return nil
+	}
+
+	return th.lastTimer()
+}
+
+func (th *testHarness) questionCount() int {
+	th.cond.L.Lock()
+	defer th.cond.L.Unlock()
+
+	return len(th.questions)
+}
+
+func (th *testHarness) answerCount() int {
+	th.cond.L.Lock()
+	defer th.cond.L.Unlock()
+
+	return len(th.answers)
+}
+
+func (th *testHarness) renameCount() int {
+	th.cond.L.Lock()
+	defer th.cond.L.Unlock()
+
+	return len(th.renames)
+}
+
+// awaitAnswers blocks until at least n answers have been written.
+func (th *testHarness) awaitAnswers(n int) bool {
+	return th.await(func() bool { return len(th.answers) >= n })
+}
+
+// awaitRenames blocks until at least n renames have occurred.
+func (th *testHarness) awaitRenames(n int) bool { //nolint:unparam
+	return th.await(func() bool { return len(th.renames) >= n })
+}
+
+// driveToProbing starts run() and waits for the first probe to be sent
+// (delay=0). Returns the timer count after the first probe.
+func (th *testHarness) driveToProbing(t *testing.T) int {
+	t.Helper()
+
+	go th.pm.run(th.closed)
+	ft := th.awaitTimer(1)
+	require.NotNil(t, ft, "expected timer after first probe")
+	require.Equal(t, 1, th.questionCount(), "first probe should be sent")
+
+	return 1 // timer count.
+}
+
+// driveToAnnouncing drives through all 3 probes into announcing state.
+// Returns the timer count after entering announcing.
+func (th *testHarness) driveToAnnouncing(t *testing.T) int {
+	t.Helper()
+	tc := th.driveToProbing(t)
+
+	// Probes 2 and 3.
+	for i := 2; i <= probeCount; i++ {
+		th.advance(probeInterval)
+		ft := th.awaitTimer(tc)
+		require.NotNil(t, ft)
+		ft.fire()
+		tc++
+		th.awaitTimer(tc)
+	}
+
+	// Transition to announcing.
+	th.advance(probeInterval)
+	ft := th.awaitTimer(tc)
+	require.NotNil(t, ft)
+	ft.fire()
+	tc++
+	th.awaitTimer(tc)
+	require.Equal(t, 1, th.answerCount(), "first announcement")
+
+	return tc
+}
+
+// driveToEstablished drives through probing and announcing to established state.
+func (th *testHarness) driveToEstablished(t *testing.T) {
+	t.Helper()
+	tc := th.driveToAnnouncing(t)
+
+	// Second announcement.
+	th.advance(announceInterval)
+	ft := th.awaitTimer(tc)
+	require.NotNil(t, ft)
+	ft.fire()
+	require.True(t, th.awaitAnswers(2), "second announcement")
+}
+
+type probeTestQuestionWriter struct{ th *testHarness }
+
+func (w *probeTestQuestionWriter) writeQuestion(b []byte) {
+	w.th.cond.L.Lock()
+	w.th.questions = append(w.th.questions, b)
+	w.th.cond.L.Unlock()
+	w.th.cond.Broadcast()
+}
+
+type probeTestAnswerWriter struct{ th *testHarness }
+
+func (w *probeTestAnswerWriter) writeAnswer(_ int, b []byte, _, _ bool, _ *net.UDPAddr) {
+	w.th.cond.L.Lock()
+	w.th.answers = append(w.th.answers, b)
+	w.th.cond.L.Unlock()
+	w.th.cond.Broadcast()
+}
+
+func testARecord(name string) dnsmessage.Resource {
+	n, _ := dnsmessage.NewName(name)
+
+	return dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{
+			Name:  n,
+			Type:  dnsmessage.TypeA,
+			Class: dnsmessage.ClassINET,
+			TTL:   120,
+		},
+		Body: &dnsmessage.AResource{A: [4]byte{192, 168, 1, 1}},
+	}
+}
+
+func testAAAARecord(name string) dnsmessage.Resource {
+	n, _ := dnsmessage.NewName(name)
+
+	return dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{
+			Name:  n,
+			Type:  dnsmessage.TypeAAAA,
+			Class: dnsmessage.ClassINET,
+			TTL:   120,
+		},
+		Body: &dnsmessage.AAAAResource{AAAA: [16]byte{0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}},
+	}
+}
+
+// TestProbeManagerNoSessions verifies that a manager with no sessions
+// closes ready immediately and exits.
+func TestProbeManagerNoSessions(t *testing.T) {
+	th := newTestHarness()
+
+	go th.pm.run(th.closed)
+	<-th.pm.ready
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestProbeManagerFullLifecycle drives a single session through
+// delay → probing (3 probes) → announcing (2 announcements) → established.
+func TestProbeManagerFullLifecycle(t *testing.T) {
+	th := newTestHarness()
+
+	rec := testARecord("myhost.local.")
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{rec}, true)
+	assert.True(t, th.pm.isProbing("myhost.local."))
+
+	go th.pm.run(th.closed)
+
+	// Delay is 0 → first probe fires immediately, then a timer is created.
+	ft := th.awaitTimer(1)
+	require.NotNil(t, ft)
+	assert.Equal(t, 1, th.questionCount(), "first probe")
+
+	// Second probe.
+	th.advance(probeInterval)
+	ft.fire()
+	ft = th.awaitTimer(2)
+	require.NotNil(t, ft)
+	assert.Equal(t, 2, th.questionCount(), "second probe")
+
+	// Third probe.
+	th.advance(probeInterval)
+	ft.fire()
+	ft = th.awaitTimer(3)
+	require.NotNil(t, ft)
+	assert.Equal(t, 3, th.questionCount(), "third probe")
+
+	// Transition to announcing → first announcement.
+	th.advance(probeInterval)
+	ft.fire()
+	ft = th.awaitTimer(4)
+	require.NotNil(t, ft)
+	assert.Equal(t, 1, th.answerCount(), "first announcement")
+
+	// Second announcement.
+	th.advance(announceInterval)
+	ft.fire()
+	require.True(t, th.awaitAnswers(2), "second announcement")
+
+	// Should be established now; ready closed.
+	<-th.pm.ready
+	assert.False(t, th.pm.isProbing("myhost.local."))
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestProbeQueryFormat verifies the wire format of a probe query.
+func TestProbeQueryFormat(t *testing.T) {
+	rec := testARecord("myhost.local.")
+
+	raw, err := buildProbeQuery("myhost.local.", []dnsmessage.Resource{rec})
+	require.NoError(t, err)
+
+	var msg dnsmessage.Message
+	require.NoError(t, msg.Unpack(raw))
+
+	assert.False(t, msg.Header.Response)
+	require.Len(t, msg.Questions, 1)
+	assert.Equal(t, typeANY, msg.Questions[0].Type)
+	assert.True(t, msg.Questions[0].Class&qClassUnicastResponse != 0, "QU bit should be set")
+	require.Len(t, msg.Authorities, 1)
+	assert.Equal(t, dnsmessage.TypeA, msg.Authorities[0].Header.Type)
+}
+
+// TestAnnouncementFormat verifies the wire format of an announcement.
+func TestAnnouncementFormat(t *testing.T) {
+	aRec := testARecord("myhost.local.")
+
+	ptrName, _ := dnsmessage.NewName("_http._tcp.local.")
+	ptrRec := dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{
+			Name:  ptrName,
+			Type:  dnsmessage.TypePTR,
+			Class: dnsmessage.ClassINET,
+			TTL:   4500,
+		},
+		Body: &dnsmessage.PTRResource{PTR: ptrName},
+	}
+
+	raw, err := buildAnnouncement([]dnsmessage.Resource{aRec, ptrRec})
+	require.NoError(t, err)
+
+	var msg dnsmessage.Message
+	require.NoError(t, msg.Unpack(raw))
+
+	assert.True(t, msg.Header.Response)
+	assert.True(t, msg.Header.Authoritative)
+	require.Len(t, msg.Answers, 2)
+
+	// A record should have cache-flush bit.
+	assert.NotZero(t, msg.Answers[0].Header.Class&rrClassCacheFlush, "A record should have cache-flush bit")
+	// PTR record should NOT have cache-flush bit (shared).
+	assert.Zero(t, msg.Answers[1].Header.Class&rrClassCacheFlush, "PTR record should not have cache-flush bit")
+}
+
+// TestConflictDuringProbing verifies that an answer for our name during
+// probing triggers a conflict and rename.
+func TestConflictDuringProbing(t *testing.T) {
+	th := newTestHarness()
+
+	rec := testARecord("myhost.local.")
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{rec}, true)
+	th.driveToProbing(t)
+
+	// Send a conflicting response.
+	conflicting := &dnsmessage.Message{
+		Header: dnsmessage.Header{Response: true},
+		Answers: []dnsmessage.Resource{{
+			Header: dnsmessage.ResourceHeader{
+				Name:  rec.Header.Name,
+				Type:  dnsmessage.TypeA,
+				Class: dnsmessage.ClassINET,
+				TTL:   120,
+			},
+			Body: &dnsmessage.AResource{A: [4]byte{10, 0, 0, 1}},
+		}},
+	}
+	th.pm.handleMessage(conflicting)
+
+	// The conflict triggers a rename and re-probe after a delay.
+	th.advance(probeDelay)
+	require.True(t, th.awaitRenames(1), "expected one rename")
+	assert.True(t, th.pm.isProbing("myhost-2.local."), "should be probing renamed host")
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestNoConflictOwnRData verifies that our own responses (matching rdata)
+// do not trigger false conflicts.
+func TestNoConflictOwnRData(t *testing.T) {
+	th := newTestHarness()
+
+	rec := testARecord("myhost.local.")
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{rec}, true)
+	tc := th.driveToAnnouncing(t)
+
+	// Send back our own announcement (same rdata).
+	ownAnswer := &dnsmessage.Message{
+		Header: dnsmessage.Header{Response: true},
+		Answers: []dnsmessage.Resource{{
+			Header: rec.Header,
+			Body:   rec.Body,
+		}},
+	}
+	th.pm.handleMessage(ownAnswer)
+
+	// Complete announcing.
+	th.advance(announceInterval)
+	ft := th.awaitTimer(tc)
+	require.NotNil(t, ft)
+	ft.fire()
+
+	<-th.pm.ready
+	assert.False(t, th.pm.isProbing("myhost.local."))
+	assert.Equal(t, 0, th.renameCount(), "no rename for our own rdata")
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestNoConflictMultipleAddresses verifies that a response matching one
+// of multiple A records does not trigger a false conflict.
+func TestNoConflictMultipleAddresses(t *testing.T) {
+	th := newTestHarness()
+
+	name := "myhost.local."
+	n, _ := dnsmessage.NewName(name)
+	rec1 := dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: n, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: 120},
+		Body:   &dnsmessage.AResource{A: [4]byte{192, 168, 1, 1}},
+	}
+	rec2 := dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: n, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: 120},
+		Body:   &dnsmessage.AResource{A: [4]byte{10, 0, 0, 5}},
+	}
+
+	th.pm.addSession(name, []dnsmessage.Resource{rec1, rec2}, true)
+	tc := th.driveToAnnouncing(t)
+
+	// Send response matching only the first address — should NOT conflict.
+	th.pm.handleMessage(&dnsmessage.Message{
+		Header:  dnsmessage.Header{Response: true},
+		Answers: []dnsmessage.Resource{{Header: rec1.Header, Body: rec1.Body}},
+	})
+
+	// Send response matching only the second address — also not a conflict.
+	th.pm.handleMessage(&dnsmessage.Message{
+		Header:  dnsmessage.Header{Response: true},
+		Answers: []dnsmessage.Resource{{Header: rec2.Header, Body: rec2.Body}},
+	})
+
+	// Complete announcing.
+	th.advance(announceInterval)
+	ft := th.awaitTimer(tc)
+	require.NotNil(t, ft)
+	ft.fire()
+
+	<-th.pm.ready
+	assert.Equal(t, 0, th.renameCount(), "no rename for our own addresses")
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestTiebreakingWeWin verifies that when our records are lexicographically
+// greater, we continue probing (we win the tiebreak).
+func TestTiebreakingWeWin(t *testing.T) {
+	th := newTestHarness()
+
+	dnsName, _ := dnsmessage.NewName("myhost.local.")
+	ours := dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: dnsName, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: 120},
+		Body:   &dnsmessage.AResource{A: [4]byte{192, 168, 1, 100}},
+	}
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{ours}, true)
+	th.driveToProbing(t)
+
+	// Simultaneous probe from another host with lower address (we win).
+	th.pm.handleMessage(&dnsmessage.Message{
+		Header:    dnsmessage.Header{Response: false},
+		Questions: []dnsmessage.Question{{Name: dnsName, Type: typeANY, Class: dnsmessage.ClassINET}},
+		Authorities: []dnsmessage.Resource{{
+			Header: dnsmessage.ResourceHeader{Name: dnsName, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: 120},
+			Body:   &dnsmessage.AResource{A: [4]byte{10, 0, 0, 1}},
+		}},
+	})
+
+	// Wait for event loop to process the message (creates next timer).
+	th.awaitTimer(2)
+	assert.Equal(t, 0, th.renameCount())
+	assert.True(t, th.pm.isProbing("myhost.local."))
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestTiebreakingWeLose verifies that when our records are lexicographically
+// lower, we defer (lose the tiebreak) and re-probe the same name after 1s
+// (§8.2 — no rename, just a delay to guard against stale probes).
+func TestTiebreakingWeLose(t *testing.T) {
+	th := newTestHarness()
+
+	dnsName, _ := dnsmessage.NewName("myhost.local.")
+	ours := dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: dnsName, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: 120},
+		Body:   &dnsmessage.AResource{A: [4]byte{10, 0, 0, 1}},
+	}
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{ours}, true)
+	tc := th.driveToProbing(t)
+
+	// Simultaneous probe from another host with higher address (we lose).
+	th.pm.handleMessage(&dnsmessage.Message{
+		Header:    dnsmessage.Header{Response: false},
+		Questions: []dnsmessage.Question{{Name: dnsName, Type: typeANY, Class: dnsmessage.ClassINET}},
+		Authorities: []dnsmessage.Resource{{
+			Header: dnsmessage.ResourceHeader{Name: dnsName, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: 120},
+			Body:   &dnsmessage.AResource{A: [4]byte{192, 168, 1, 100}},
+		}},
+	})
+
+	// Tiebreak loss waits 1s and re-probes the same name (no rename).
+	th.advance(time.Second)
+	ft := th.awaitTimer(tc + 1)
+	require.NotNil(t, ft)
+	assert.Equal(t, 0, th.renameCount(), "tiebreak should not rename")
+	assert.True(t, th.pm.isProbing("myhost.local."), "should re-probe same name")
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestConflictHandlerStop verifies the user can stop probing via the handler.
+func TestConflictHandlerStop(t *testing.T) {
+	th := newTestHarness()
+	th.pm.conflictHandler = func(evt ConflictEvent) ConflictAction {
+		return ConflictAction{Stop: true}
+	}
+
+	rec := testARecord("myhost.local.")
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{rec}, true)
+	th.driveToProbing(t)
+
+	// Send conflicting response.
+	th.pm.handleMessage(&dnsmessage.Message{
+		Header: dnsmessage.Header{Response: true},
+		Answers: []dnsmessage.Resource{{
+			Header: rec.Header,
+			Body:   &dnsmessage.AResource{A: [4]byte{10, 0, 0, 1}},
+		}},
+	})
+
+	// Should be stopped — ready closed.
+	<-th.pm.ready
+	assert.False(t, th.pm.isProbing("myhost.local."))
+	assert.Equal(t, 0, th.renameCount(), "handler stopped, no rename")
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestConflictHandlerCustomRename verifies the user can provide a custom name.
+func TestConflictHandlerCustomRename(t *testing.T) {
+	th := newTestHarness()
+	th.pm.conflictHandler = func(evt ConflictEvent) ConflictAction {
+		return ConflictAction{Rename: "custom.local."}
+	}
+
+	rec := testARecord("myhost.local.")
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{rec}, true)
+	th.driveToProbing(t)
+
+	// Send conflicting response.
+	th.pm.handleMessage(&dnsmessage.Message{
+		Header: dnsmessage.Header{Response: true},
+		Answers: []dnsmessage.Resource{{
+			Header: rec.Header,
+			Body:   &dnsmessage.AResource{A: [4]byte{10, 0, 0, 1}},
+		}},
+	})
+
+	// Process conflict.
+	th.advance(probeDelay)
+	require.True(t, th.awaitRenames(1))
+
+	assert.True(t, th.pm.isProbing("custom.local."), "should be probing custom name")
+	th.cond.L.Lock()
+	require.NotEmpty(t, th.renames)
+	r := th.renames[0]
+	th.cond.L.Unlock()
+	assert.Equal(t, "myhost.local.", r.oldName)
+	assert.Equal(t, "custom.local.", r.newName)
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestLexicographicCompare tests the tiebreaking comparison.
+func TestLexicographicCompare(t *testing.T) {
+	n, _ := dnsmessage.NewName("x.local.")
+	makeA := func(addr [4]byte) dnsmessage.Resource {
+		return dnsmessage.Resource{
+			Header: dnsmessage.ResourceHeader{Name: n, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET},
+			Body:   &dnsmessage.AResource{A: addr},
+		}
+	}
+
+	tests := []struct {
+		desc string
+		ours []dnsmessage.Resource
+		them []dnsmessage.Resource
+		want int
+	}{
+		{
+			desc: "equal",
+			ours: []dnsmessage.Resource{makeA([4]byte{1, 2, 3, 4})},
+			them: []dnsmessage.Resource{makeA([4]byte{1, 2, 3, 4})},
+			want: 0,
+		},
+		{
+			desc: "ours higher",
+			ours: []dnsmessage.Resource{makeA([4]byte{192, 168, 1, 1})},
+			them: []dnsmessage.Resource{makeA([4]byte{10, 0, 0, 1})},
+			want: 1,
+		},
+		{
+			desc: "ours lower",
+			ours: []dnsmessage.Resource{makeA([4]byte{10, 0, 0, 1})},
+			them: []dnsmessage.Resource{makeA([4]byte{192, 168, 1, 1})},
+			want: -1,
+		},
+		{
+			desc: "ours has more records wins",
+			ours: []dnsmessage.Resource{makeA([4]byte{1, 2, 3, 4}), makeA([4]byte{5, 6, 7, 8})},
+			them: []dnsmessage.Resource{makeA([4]byte{1, 2, 3, 4})},
+			want: 1,
+		},
+		{
+			desc: "ours has fewer records loses",
+			ours: []dnsmessage.Resource{makeA([4]byte{1, 2, 3, 4})},
+			them: []dnsmessage.Resource{makeA([4]byte{1, 2, 3, 4}), makeA([4]byte{5, 6, 7, 8})},
+			want: -1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := lexicographicCompare(tc.ours, tc.them)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestDefaultRenameHost tests hostname rename strategy.
+func TestDefaultRenameHost(t *testing.T) {
+	tests := []struct {
+		input string
+		count int
+		want  string
+	}{
+		{"myhost.local.", 1, "myhost-2.local."},
+		{"myhost.local.", 2, "myhost-3.local."},
+		{"myhost-2.local.", 3, "myhost-4.local."},
+	}
+	for _, tc := range tests {
+		got := defaultRename(tc.input, tc.count, true)
+		assert.Equal(t, tc.want, got, "rename %q count=%d", tc.input, tc.count)
+	}
+}
+
+// TestDefaultRenameServiceInstance tests service instance rename strategy.
+func TestDefaultRenameServiceInstance(t *testing.T) {
+	tests := []struct {
+		input string
+		count int
+		want  string
+	}{
+		{"My Service._http._tcp.local.", 1, "My Service (2)._http._tcp.local."},
+		{"My Service._http._tcp.local.", 2, "My Service (3)._http._tcp.local."},
+		{"My Service (2)._http._tcp.local.", 3, "My Service (4)._http._tcp.local."},
+	}
+	for _, tc := range tests {
+		got := defaultRename(tc.input, tc.count, false)
+		assert.Equal(t, tc.want, got, "rename %q count=%d", tc.input, tc.count)
+	}
+}
+
+// TestIsProbingCaseInsensitive verifies case-insensitive matching.
+func TestIsProbingCaseInsensitive(t *testing.T) {
+	th := newTestHarness()
+	rec := testARecord("MyHost.local.")
+	th.pm.addSession("MyHost.local.", []dnsmessage.Resource{rec}, true)
+
+	assert.True(t, th.pm.isProbing("myhost.local."))
+	assert.True(t, th.pm.isProbing("MYHOST.LOCAL."))
+	assert.False(t, th.pm.isProbing("other.local."))
+}
+
+// TestHandleMessageAfterDone verifies handleMessage does not block after
+// the event loop exits.
+func TestHandleMessageAfterDone(t *testing.T) {
+	th := newTestHarness()
+
+	go th.pm.run(th.closed)
+	<-th.pm.ready
+	close(th.closed)
+	<-th.pm.done
+
+	// Should return immediately, not block.
+	returned := make(chan struct{})
+
+	go func() {
+		th.pm.handleMessage(&dnsmessage.Message{})
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		assert.Fail(t, "handleMessage blocked after done")
+	}
+}
+
+// TestConflictInEstablishedState verifies that a response with foreign rdata
+// in established state triggers re-probing.
+func TestConflictInEstablishedState(t *testing.T) {
+	th := newTestHarness()
+
+	rec := testARecord("myhost.local.")
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{rec}, true)
+	th.driveToEstablished(t)
+	<-th.pm.ready
+
+	// Now send a conflicting response in established state.
+	conflicting := &dnsmessage.Message{
+		Header: dnsmessage.Header{Response: true},
+		Answers: []dnsmessage.Resource{{
+			Header: rec.Header,
+			Body:   &dnsmessage.AResource{A: [4]byte{10, 0, 0, 99}},
+		}},
+	}
+	th.pm.handleMessage(conflicting)
+
+	// Advance to let conflict processing occur.
+	th.advance(probeDelay)
+	require.True(t, th.awaitRenames(1), "conflict in established state should rename")
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestIsConflictingRData verifies the rdata conflict detection logic.
+func TestIsConflictingRData(t *testing.T) {
+	th := newTestHarness()
+
+	dnsName, _ := dnsmessage.NewName("test.local.")
+	rec1 := dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: dnsName, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET},
+		Body:   &dnsmessage.AResource{A: [4]byte{192, 168, 1, 1}},
+	}
+	rec2 := dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: dnsName, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET},
+		Body:   &dnsmessage.AResource{A: [4]byte{10, 0, 0, 5}},
+	}
+	session := &probeSession{
+		name:    "test.local.",
+		records: []dnsmessage.Resource{rec1, rec2},
+	}
+
+	// Answer matching first record — not a conflict.
+	ans1 := &dnsmessage.Resource{Header: rec1.Header, Body: &dnsmessage.AResource{A: [4]byte{192, 168, 1, 1}}}
+	assert.False(t, th.pm.isConflictingRData(session, ans1), "matching first record")
+
+	// Answer matching second record — not a conflict.
+	ans2 := &dnsmessage.Resource{Header: rec2.Header, Body: &dnsmessage.AResource{A: [4]byte{10, 0, 0, 5}}}
+	assert.False(t, th.pm.isConflictingRData(session, ans2), "matching second record")
+
+	// Answer matching neither — conflict.
+	ansForeign := &dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: dnsName, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET},
+		Body:   &dnsmessage.AResource{A: [4]byte{172, 16, 0, 1}},
+	}
+	assert.True(t, th.pm.isConflictingRData(session, ansForeign), "foreign address")
+
+	// Answer with different type — not a conflict.
+	ansAAAA := &dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: dnsName, Type: dnsmessage.TypeAAAA, Class: dnsmessage.ClassINET},
+		Body:   &dnsmessage.AAAAResource{},
+	}
+	assert.False(t, th.pm.isConflictingRData(session, ansAAAA), "different record type")
+}
+
+// TestConflictEventFields verifies the ConflictEvent passed to the handler.
+func TestConflictEventFields(t *testing.T) {
+	th := newTestHarness()
+
+	var captured ConflictEvent
+	th.pm.conflictHandler = func(evt ConflictEvent) ConflictAction {
+		captured = evt
+
+		return ConflictAction{}
+	}
+
+	rec := testARecord("myhost.local.")
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{rec}, true)
+	th.driveToProbing(t)
+
+	// Conflict.
+	th.pm.handleMessage(&dnsmessage.Message{
+		Header: dnsmessage.Header{Response: true},
+		Answers: []dnsmessage.Resource{{
+			Header: rec.Header,
+			Body:   &dnsmessage.AResource{A: [4]byte{10, 0, 0, 1}},
+		}},
+	})
+
+	th.advance(probeDelay)
+	require.True(t, th.awaitRenames(1))
+
+	assert.True(t, strings.EqualFold(captured.Name, "myhost.local."))
+	assert.Equal(t, 1, captured.Count)
+	assert.True(t, captured.Host)
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestPackRData covers the rdata serialization for comparison.
+func TestPackRData(t *testing.T) {
+	// A record.
+	aBody := &dnsmessage.AResource{A: [4]byte{1, 2, 3, 4}}
+	assert.Equal(t, []byte{1, 2, 3, 4}, packRData(aBody))
+
+	// AAAA record.
+	aaaa := [16]byte{0xfe, 0x80}
+	assert.Equal(t, aaaa[:], packRData(&dnsmessage.AAAAResource{AAAA: aaaa}))
+
+	// TXT record.
+	txtData := packRData(&dnsmessage.TXTResource{TXT: []string{"k=v"}})
+	assert.Equal(t, []byte{3, 'k', '=', 'v'}, txtData)
+
+	// SRV record.
+	target, _ := dnsmessage.NewName("myhost.local.")
+	srvData := packRData(&dnsmessage.SRVResource{
+		Priority: 0, Weight: 0, Port: 8080, Target: target,
+	})
+	assert.NotNil(t, srvData)
+	assert.Equal(t, uint16(8080), binary.BigEndian.Uint16(srvData[4:6]))
+
+	// PTR record.
+	ptrName, _ := dnsmessage.NewName("_http._tcp.local.")
+	ptrData := packRData(&dnsmessage.PTRResource{PTR: ptrName})
+	assert.NotNil(t, ptrData)
+	assert.NotEmpty(t, ptrData)
+
+	// Unknown type returns nil.
+	assert.Nil(t, packRData(&dnsmessage.NSResource{}))
+
+	// Nil body.
+	assert.Nil(t, packRData(nil))
+}
+
+// TestShouldBackoff verifies the rate-limiting backoff logic directly.
+func TestShouldBackoff(t *testing.T) {
+	th := newTestHarness()
+	now := th.clock
+
+	session := &probeSession{name: "test.local."}
+
+	// Fill conflict times within the rate window.
+	for i := 0; i < conflictRateLimit-1; i++ {
+		session.conflictTimes = append(session.conflictTimes, now.Add(time.Duration(i)*time.Second))
+	}
+
+	// Not yet at the limit.
+	assert.Equal(t, time.Duration(0), th.pm.shouldBackoff(session, now.Add(9*time.Second)))
+
+	// Add one more to hit the limit.
+	session.conflictTimes = append(session.conflictTimes, now.Add(9*time.Second))
+	assert.Equal(t, conflictBackoff, th.pm.shouldBackoff(session, now.Add(9*time.Second)))
+
+	// After the window passes, old entries are pruned.
+	assert.Equal(t, time.Duration(0), th.pm.shouldBackoff(session, now.Add(20*time.Second)))
+}
+
+// TestConflictGiveUp verifies that handleConflictForSession stops the
+// session after sustained conflicts over the give-up period.
+func TestConflictGiveUp(t *testing.T) {
+	th := newTestHarness()
+	now := th.clock
+
+	rec := testARecord("test.local.")
+	session := &probeSession{
+		name:    "test.local.",
+		state:   probeStateProbing,
+		isHost:  true,
+		records: []dnsmessage.Resource{rec},
+	}
+
+	step := conflictGiveUp/time.Duration(conflictRateLimit) + time.Second
+
+	for i := 0; i <= conflictRateLimit+1; i++ {
+		now = now.Add(step)
+		session.conflict = true
+
+		var pio pendingIO
+
+		th.pm.mu.Lock()
+		th.pm.handleConflictForSession(session, now, &pio)
+		th.pm.mu.Unlock()
+
+		if session.state == probeStateStopped {
+			break
+		}
+	}
+
+	assert.Equal(t, probeStateStopped, session.state, "session should stop after sustained conflicts")
+}
+
+// TestDefaultRenameHostNoDot tests hostname rename with no domain part.
+func TestDefaultRenameHostNoDot(t *testing.T) {
+	got := defaultRename("myhost", 1, true)
+	assert.Equal(t, "myhost-2", got)
+}
+
+// TestDefaultRenameHostNonNumericSuffix verifies a host with a non-numeric
+// dash suffix keeps the dash.
+func TestDefaultRenameHostNonNumericSuffix(t *testing.T) {
+	got := defaultRename("my-host.local.", 1, true)
+	assert.Equal(t, "my-host-2.local.", got)
+}
+
+// TestDefaultRenameServiceNoUnderscore tests service rename with no
+// underscore boundary.
+func TestDefaultRenameServiceNoUnderscore(t *testing.T) {
+	got := defaultRename("noservice.local.", 1, false)
+	assert.Equal(t, "noservice.local. (2)", got)
+}
+
+// TestDefaultRenameServiceNonNumericParen tests service rename where the
+// paren suffix is non-numeric.
+func TestDefaultRenameServiceNonNumericParen(t *testing.T) {
+	got := defaultRename("My Service (beta)._http._tcp.local.", 1, false)
+	assert.Equal(t, "My Service (beta) (2)._http._tcp.local.", got)
+}
+
+// TestCompareResourceDifferentClass verifies class comparison in tiebreaking.
+func TestCompareResourceDifferentClass(t *testing.T) {
+	n, _ := dnsmessage.NewName("x.local.")
+
+	// Class CSNET(2) < Class IN(1) is false; IN < CSNET.
+	resClass1 := dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: n, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET},
+		Body:   &dnsmessage.AResource{A: [4]byte{1, 2, 3, 4}},
+	}
+	resClass2 := dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: n, Type: dnsmessage.TypeA, Class: dnsmessage.ClassCSNET},
+		Body:   &dnsmessage.AResource{A: [4]byte{1, 2, 3, 4}},
+	}
+
+	assert.NotEqual(t, 0, compareResource(resClass1, resClass2))
+}
+
+// TestCompareResourceDifferentType verifies type comparison in tiebreaking.
+func TestCompareResourceDifferentType(t *testing.T) {
+	n, _ := dnsmessage.NewName("x.local.")
+
+	resA := dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: n, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET},
+		Body:   &dnsmessage.AResource{A: [4]byte{1, 2, 3, 4}},
+	}
+	resAAAA := dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: n, Type: dnsmessage.TypeAAAA, Class: dnsmessage.ClassINET},
+		Body:   &dnsmessage.AAAAResource{AAAA: [16]byte{1}},
+	}
+
+	// TypeA=1 < TypeAAAA=28 → negative.
+	assert.Equal(t, -1, compareResource(resA, resAAAA))
+	assert.Equal(t, 1, compareResource(resAAAA, resA))
+}
+
+// TestProbeQueryMultipleRecords verifies probe with multiple authority records.
+func TestProbeQueryMultipleRecords(t *testing.T) {
+	aRec := testARecord("myhost.local.")
+	aaaaRec := testAAAARecord("myhost.local.")
+
+	raw, err := buildProbeQuery("myhost.local.", []dnsmessage.Resource{aRec, aaaaRec})
+	require.NoError(t, err)
+
+	var msg dnsmessage.Message
+	require.NoError(t, msg.Unpack(raw))
+
+	require.Len(t, msg.Questions, 1)
+	require.Len(t, msg.Authorities, 2)
+	assert.Equal(t, dnsmessage.TypeA, msg.Authorities[0].Header.Type)
+	assert.Equal(t, dnsmessage.TypeAAAA, msg.Authorities[1].Header.Type)
+}
+
+// TestProbeWithQuestionNoAuthority verifies that an incoming query without
+// authority records does not cause a tiebreak.
+func TestProbeWithQuestionNoAuthority(t *testing.T) {
+	th := newTestHarness()
+
+	rec := testARecord("myhost.local.")
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{rec}, true)
+	th.driveToProbing(t)
+
+	n, _ := dnsmessage.NewName("myhost.local.")
+	th.pm.handleMessage(&dnsmessage.Message{
+		Header:    dnsmessage.Header{Response: false},
+		Questions: []dnsmessage.Question{{Name: n, Type: typeANY, Class: dnsmessage.ClassINET}},
+		// No authority section.
+	})
+
+	// Wait for event loop to process (creates next timer).
+	th.awaitTimer(2)
+	assert.Equal(t, 0, th.renameCount(), "no tiebreak without authority records")
+	assert.True(t, th.pm.isProbing("myhost.local."))
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestMultipleSessions verifies that host and service sessions can probe
+// concurrently.
+func TestMultipleSessions(t *testing.T) {
+	th := newTestHarness()
+
+	hostRec := testARecord("myhost.local.")
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{hostRec}, true)
+
+	svcName, _ := dnsmessage.NewName("My Service._http._tcp.local.")
+	srvRec := dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: svcName, Type: dnsmessage.TypeSRV, Class: dnsmessage.ClassINET, TTL: 120},
+		Body:   &dnsmessage.SRVResource{Port: 8080, Target: hostRec.Header.Name},
+	}
+	th.pm.addSession("My Service._http._tcp.local.", []dnsmessage.Resource{srvRec}, false)
+
+	assert.True(t, th.pm.isProbing("myhost.local."))
+	assert.True(t, th.pm.isProbing("My Service._http._tcp.local."))
+
+	// Drive manually: with 2 sessions, each step produces 2 probes/announces.
+	go th.pm.run(th.closed)
+
+	// First probes (both sessions fire together).
+	ft := th.awaitTimer(1)
+	require.NotNil(t, ft)
+	assert.Equal(t, 2, th.questionCount(), "both sessions probe initially")
+
+	// Second probes.
+	th.advance(probeInterval)
+	ft.fire()
+	ft = th.awaitTimer(2)
+	require.NotNil(t, ft)
+	assert.Equal(t, 4, th.questionCount())
+
+	// Third probes.
+	th.advance(probeInterval)
+	ft.fire()
+	ft = th.awaitTimer(3)
+	require.NotNil(t, ft)
+	assert.Equal(t, 6, th.questionCount())
+
+	// Transition to announcing → first announcements.
+	th.advance(probeInterval)
+	ft.fire()
+	ft = th.awaitTimer(4)
+	require.NotNil(t, ft)
+	assert.Equal(t, 2, th.answerCount(), "first announcements for both")
+
+	// Second announcements → established.
+	th.advance(announceInterval)
+	ft.fire()
+	require.True(t, th.awaitAnswers(4), "second announcements for both")
+
+	<-th.pm.ready
+	assert.False(t, th.pm.isProbing("myhost.local."))
+	assert.False(t, th.pm.isProbing("My Service._http._tcp.local."))
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestConflictDuringAnnouncing verifies that a conflict detected during
+// announcing triggers a rename and re-probe.
+func TestConflictDuringAnnouncing(t *testing.T) {
+	th := newTestHarness()
+
+	rec := testARecord("myhost.local.")
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{rec}, true)
+	th.driveToAnnouncing(t)
+
+	// Send a conflicting response during announcing.
+	th.pm.handleMessage(&dnsmessage.Message{
+		Header: dnsmessage.Header{Response: true},
+		Answers: []dnsmessage.Resource{{
+			Header: rec.Header,
+			Body:   &dnsmessage.AResource{A: [4]byte{10, 0, 0, 42}},
+		}},
+	})
+
+	th.advance(probeDelay)
+	require.True(t, th.awaitRenames(1), "conflict during announcing should rename")
+	assert.True(t, th.pm.isProbing("myhost-2.local."), "should be probing renamed host")
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestAnnouncementCacheFlushBits verifies that A/AAAA/SRV/TXT records have
+// the cache-flush bit set, while PTR records do not.
+func TestAnnouncementCacheFlushBits(t *testing.T) {
+	dnsName, _ := dnsmessage.NewName("myhost.local.")
+	ptrName, _ := dnsmessage.NewName("_http._tcp.local.")
+	svcName, _ := dnsmessage.NewName("My Svc._http._tcp.local.")
+
+	records := []dnsmessage.Resource{
+		{
+			Header: dnsmessage.ResourceHeader{Name: dnsName, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: 120},
+			Body:   &dnsmessage.AResource{A: [4]byte{1, 2, 3, 4}},
+		},
+		{
+			Header: dnsmessage.ResourceHeader{Name: dnsName, Type: dnsmessage.TypeAAAA, Class: dnsmessage.ClassINET, TTL: 120},
+			Body:   &dnsmessage.AAAAResource{AAAA: [16]byte{0xfe, 0x80}},
+		},
+		{
+			Header: dnsmessage.ResourceHeader{Name: svcName, Type: dnsmessage.TypeSRV, Class: dnsmessage.ClassINET, TTL: 120},
+			Body:   &dnsmessage.SRVResource{Port: 80, Target: dnsName},
+		},
+		{
+			Header: dnsmessage.ResourceHeader{Name: svcName, Type: dnsmessage.TypeTXT, Class: dnsmessage.ClassINET, TTL: 120},
+			Body:   &dnsmessage.TXTResource{TXT: []string{"k=v"}},
+		},
+		{
+			Header: dnsmessage.ResourceHeader{Name: ptrName, Type: dnsmessage.TypePTR, Class: dnsmessage.ClassINET, TTL: 4500},
+			Body:   &dnsmessage.PTRResource{PTR: svcName},
+		},
+	}
+
+	raw, err := buildAnnouncement(records)
+	require.NoError(t, err)
+
+	var msg dnsmessage.Message
+	require.NoError(t, msg.Unpack(raw))
+	require.Len(t, msg.Answers, 5)
+
+	// A, AAAA, SRV, TXT should have cache-flush bit.
+	for _, idx := range []int{0, 1, 2, 3} {
+		assert.NotZero(t, msg.Answers[idx].Header.Class&rrClassCacheFlush,
+			"record type %d should have cache-flush bit", msg.Answers[idx].Header.Type)
+	}
+
+	// PTR should NOT have cache-flush bit.
+	assert.Zero(t, msg.Answers[4].Header.Class&rrClassCacheFlush, "PTR should not have cache-flush bit")
+}
+
+// TestPackDNSName covers edge cases in DNS name serialization.
+func TestPackDNSName(t *testing.T) {
+	// Normal name.
+	n, _ := dnsmessage.NewName("foo.local.")
+	data := packDNSName(n)
+	assert.NotEmpty(t, data)
+	assert.Equal(t, byte(0), data[len(data)-1], "should end with zero byte")
+
+	// Root/empty name.
+	root, _ := dnsmessage.NewName(".")
+	data = packDNSName(root)
+	assert.Equal(t, []byte{0}, data)
+}
+
+// TestResponseForUnrelatedName verifies that answers for names we don't
+// own are ignored.
+func TestResponseForUnrelatedName(t *testing.T) {
+	th := newTestHarness()
+
+	rec := testARecord("myhost.local.")
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{rec}, true)
+	th.driveToProbing(t)
+
+	// Send response for a completely different name.
+	otherName, _ := dnsmessage.NewName("other.local.")
+	th.pm.handleMessage(&dnsmessage.Message{
+		Header: dnsmessage.Header{Response: true},
+		Answers: []dnsmessage.Resource{{
+			Header: dnsmessage.ResourceHeader{Name: otherName, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: 120},
+			Body:   &dnsmessage.AResource{A: [4]byte{10, 0, 0, 1}},
+		}},
+	})
+
+	// Wait for event loop to process (creates next timer).
+	th.awaitTimer(2)
+	assert.Equal(t, 0, th.renameCount(), "unrelated name should not trigger conflict")
+	assert.True(t, th.pm.isProbing("myhost.local."))
+
+	close(th.closed)
+	<-th.pm.done
+}

--- a/probe_test.go
+++ b/probe_test.go
@@ -1200,6 +1200,148 @@ func TestPackDNSName(t *testing.T) {
 	assert.Equal(t, []byte{0}, data)
 }
 
+// TestSequentialConflicts drives the full event loop through two
+// consecutive rename cycles: myhost → myhost-2 → myhost-3.
+// Verifies rename events, session state, and that record headers
+// are rewritten to the new name.
+func TestSequentialConflicts(t *testing.T) {
+	th := newTestHarness()
+
+	rec := testARecord("myhost.local.")
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{rec}, true)
+
+	tc := th.driveToProbing(t)
+
+	// fire advances the clock, awaits the next timer, and fires it.
+	fire := func(d time.Duration) {
+		t.Helper()
+		tc++
+		ft := th.awaitTimer(tc)
+		require.NotNil(t, ft, "expected timer %d", tc)
+		th.advance(d)
+		ft.fire()
+	}
+
+	// conflictResponse builds a response with a foreign address for the given name.
+	conflictResponse := func(name string, addr [4]byte) *dnsmessage.Message {
+		n, _ := dnsmessage.NewName(name)
+
+		return &dnsmessage.Message{
+			Header: dnsmessage.Header{Response: true},
+			Answers: []dnsmessage.Resource{{
+				Header: dnsmessage.ResourceHeader{Name: n, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: 120},
+				Body:   &dnsmessage.AResource{A: addr},
+			}},
+		}
+	}
+
+	// First conflict → myhost-2.
+	th.pm.handleMessage(conflictResponse("myhost.local.", [4]byte{10, 0, 0, 1}))
+	th.advance(probeDelay)
+	require.True(t, th.awaitRenames(1))
+
+	th.pm.mu.RLock()
+	assert.Equal(t, "myhost-2.local.", th.pm.sessions[0].name)
+	assert.Equal(t, "myhost-2.local.", th.pm.sessions[0].records[0].Header.Name.String())
+	th.pm.mu.RUnlock()
+
+	// Drive myhost-2 into probing.
+	fire(probeDelay)
+
+	// Second conflict → myhost-3.
+	th.pm.handleMessage(conflictResponse("myhost-2.local.", [4]byte{10, 0, 0, 2}))
+	th.advance(probeDelay)
+	require.True(t, th.awaitRenames(2))
+
+	th.pm.mu.RLock()
+	assert.Equal(t, "myhost-3.local.", th.pm.sessions[0].name)
+	assert.Equal(t, "myhost-3.local.", th.pm.sessions[0].records[0].Header.Name.String())
+	th.pm.mu.RUnlock()
+
+	// Verify the full rename chain.
+	th.cond.L.Lock()
+	require.Len(t, th.renames, 2)
+	assert.Equal(t, "myhost.local.", th.renames[0].oldName)
+	assert.Equal(t, "myhost-2.local.", th.renames[0].newName)
+	assert.True(t, th.renames[0].isHost)
+	assert.Equal(t, "myhost-2.local.", th.renames[1].oldName)
+	assert.Equal(t, "myhost-3.local.", th.renames[1].newName)
+	th.cond.L.Unlock()
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestConflictRenameAnnounce drives a full conflict → rename → re-probe →
+// announce cycle and verifies the announcement wire data contains the
+// renamed name with cache-flush bits set.
+func TestConflictRenameAnnounce(t *testing.T) {
+	th := newTestHarness()
+
+	rec := testARecord("myhost.local.")
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{rec}, true)
+
+	tc := th.driveToProbing(t)
+
+	// fire advances the clock, awaits the next timer, and fires it.
+	fire := func(d time.Duration) {
+		t.Helper()
+		tc++
+		ft := th.awaitTimer(tc)
+		require.NotNil(t, ft, "expected timer %d", tc)
+		th.advance(d)
+		ft.fire()
+	}
+
+	// Inject conflict during probing.
+	th.pm.handleMessage(&dnsmessage.Message{
+		Header: dnsmessage.Header{Response: true},
+		Answers: []dnsmessage.Resource{{
+			Header: rec.Header,
+			Body:   &dnsmessage.AResource{A: [4]byte{10, 0, 0, 1}},
+		}},
+	})
+	th.advance(probeDelay)
+	require.True(t, th.awaitRenames(1))
+
+	// Drive renamed session: delay, 3 probes, transition, 2 announcements.
+	fire(probeDelay)                         // delay → first re-probe
+	fire(probeInterval)                      // second re-probe
+	fire(probeInterval)                      // third re-probe
+	fire(probeInterval)                      // transition to announcing
+	require.True(t, th.awaitAnswers(1))      // first announcement
+	fire(announceInterval)                   // second announcement
+	require.True(t, th.awaitAnswers(2))      // established
+	<-th.pm.ready
+
+	// Unpack the first announcement and verify wire content.
+	th.cond.L.Lock()
+	raw := th.answers[0]
+	th.cond.L.Unlock()
+
+	var msg dnsmessage.Message
+	require.NoError(t, msg.Unpack(raw))
+
+	assert.True(t, msg.Header.Response)
+	assert.True(t, msg.Header.Authoritative)
+	require.Len(t, msg.Answers, 1)
+
+	// Answer must use the renamed name.
+	assert.Equal(t, "myhost-2.local.", msg.Answers[0].Header.Name.String())
+	assert.Equal(t, dnsmessage.TypeA, msg.Answers[0].Header.Type)
+
+	// Cache-flush bit set (unique record).
+	assert.NotZero(t, msg.Answers[0].Header.Class&rrClassCacheFlush)
+
+	// Rdata is our original address (rename changes name, not address).
+	body, ok := msg.Answers[0].Body.(*dnsmessage.AResource)
+	require.True(t, ok)
+	assert.Equal(t, [4]byte{192, 168, 1, 1}, body.A)
+
+	close(th.closed)
+	<-th.pm.done
+}
+
 // TestResponseForUnrelatedName verifies that answers for names we don't
 // own are ignored.
 func TestResponseForUnrelatedName(t *testing.T) {

--- a/probe_test.go
+++ b/probe_test.go
@@ -59,7 +59,7 @@ func newTestHarness() *testHarness {
 	qw := &probeTestQuestionWriter{th: th}
 	aw := &probeTestAnswerWriter{th: th}
 
-	th.pm = newProbeManager(qw, aw, log, "test", 120, nil, func(oldName, newName string, isHost bool) {
+	th.pm = newProbeManager(qw, aw, log, "test", nil, func(oldName, newName string, isHost bool) {
 		th.cond.L.Lock()
 		th.renames = append(th.renames, renameEvent{oldName: oldName, newName: newName, isHost: isHost})
 		th.cond.L.Unlock()
@@ -89,6 +89,13 @@ func (th *testHarness) advance(d time.Duration) {
 	th.cond.L.Lock()
 	th.clock = th.clock.Add(d)
 	th.cond.L.Unlock()
+}
+
+func (th *testHarness) timerCount() int {
+	th.cond.L.Lock()
+	defer th.cond.L.Unlock()
+
+	return len(th.timers)
 }
 
 func (th *testHarness) lastTimer() *fakeTimer {
@@ -369,7 +376,7 @@ func TestAnnouncementFormat(t *testing.T) {
 		Body: &dnsmessage.PTRResource{PTR: ptrName},
 	}
 
-	raw, err := buildAnnouncement([]dnsmessage.Resource{aRec, ptrRec})
+	raw, err := buildAnnouncement([]dnsmessage.Resource{aRec}, []dnsmessage.Resource{ptrRec})
 	require.NoError(t, err)
 
 	var msg dnsmessage.Message
@@ -692,7 +699,8 @@ func TestDefaultRenameHost(t *testing.T) {
 	}{
 		{"myhost.local.", 1, "myhost-2.local."},
 		{"myhost.local.", 2, "myhost-3.local."},
-		{"myhost-2.local.", 3, "myhost-4.local."},
+		// A base name that itself ends in "-2" is preserved, not stripped.
+		{"myhost-2.local.", 3, "myhost-2-4.local."},
 	}
 	for _, tc := range tests {
 		got := defaultRename(tc.input, tc.count, true)
@@ -709,7 +717,8 @@ func TestDefaultRenameServiceInstance(t *testing.T) {
 	}{
 		{"My Service._http._tcp.local.", 1, "My Service (2)._http._tcp.local."},
 		{"My Service._http._tcp.local.", 2, "My Service (3)._http._tcp.local."},
-		{"My Service (2)._http._tcp.local.", 3, "My Service (4)._http._tcp.local."},
+		// A base name that itself ends in " (2)" is preserved, not stripped.
+		{"My Service (2)._http._tcp.local.", 3, "My Service (2) (4)._http._tcp.local."},
 	}
 	for _, tc := range tests {
 		got := defaultRename(tc.input, tc.count, false)
@@ -753,8 +762,9 @@ func TestHandleMessageAfterDone(t *testing.T) {
 	}
 }
 
-// TestConflictInEstablishedState verifies that a response with foreign rdata
-// in established state triggers re-probing.
+// TestConflictInEstablishedState verifies §9 semantics: a response with
+// foreign rdata in established state resets the record to probing with the
+// SAME name. A rename happens only if the re-probe also conflicts.
 func TestConflictInEstablishedState(t *testing.T) {
 	th := newTestHarness()
 
@@ -762,6 +772,9 @@ func TestConflictInEstablishedState(t *testing.T) {
 	th.pm.addSession("myhost.local.", []dnsmessage.Resource{rec}, true)
 	th.driveToEstablished(t)
 	<-th.pm.ready
+
+	probesBefore := th.questionCount()
+	timersBefore := th.timerCount()
 
 	// Now send a conflicting response in established state.
 	conflicting := &dnsmessage.Message{
@@ -773,9 +786,29 @@ func TestConflictInEstablishedState(t *testing.T) {
 	}
 	th.pm.handleMessage(conflicting)
 
-	// Advance to let conflict processing occur.
+	// §9: re-probe the same name, no rename yet.
+	delayTimer := th.awaitTimer(timersBefore + 1)
+	require.NotNil(t, delayTimer, "expected re-probe delay timer")
+	assert.True(t, th.pm.isProbing("myhost.local."), "should re-probe the same name")
+	assert.Equal(t, 0, th.renameCount(), "established conflict must not rename directly")
+
+	// Fire the delay timer: the first probe of the re-probe round goes out.
 	th.advance(probeDelay)
-	require.True(t, th.awaitRenames(1), "conflict in established state should rename")
+	delayTimer.fire()
+	require.True(t, th.await(func() bool { return len(th.questions) > probesBefore }),
+		"expected a new probe after established conflict")
+
+	// A conflict during the re-probe now triggers the rename (§8.1).
+	th.pm.handleMessage(conflicting)
+	th.advance(probeDelay)
+	require.True(t, th.awaitRenames(1), "conflict during re-probe should rename")
+
+	th.cond.L.Lock()
+	r := th.renames[0]
+	th.cond.L.Unlock()
+	assert.Equal(t, "myhost.local.", r.oldName)
+	// Count includes the established-state conflict, so the suffix is 3.
+	assert.Equal(t, "myhost-3.local.", r.newName)
 
 	close(th.closed)
 	<-th.pm.done
@@ -1114,13 +1147,16 @@ func TestMultipleSessions(t *testing.T) {
 }
 
 // TestConflictDuringAnnouncing verifies that a conflict detected during
-// announcing triggers a rename and re-probe.
+// announcing resets the record to probing with the same name (§9 — probing
+// already completed, so this is not a probing conflict).
 func TestConflictDuringAnnouncing(t *testing.T) {
 	th := newTestHarness()
 
 	rec := testARecord("myhost.local.")
 	th.pm.addSession("myhost.local.", []dnsmessage.Resource{rec}, true)
 	th.driveToAnnouncing(t)
+
+	timersBefore := th.timerCount()
 
 	// Send a conflicting response during announcing.
 	th.pm.handleMessage(&dnsmessage.Message{
@@ -1131,22 +1167,22 @@ func TestConflictDuringAnnouncing(t *testing.T) {
 		}},
 	})
 
-	th.advance(probeDelay)
-	require.True(t, th.awaitRenames(1), "conflict during announcing should rename")
-	assert.True(t, th.pm.isProbing("myhost-2.local."), "should be probing renamed host")
+	require.NotNil(t, th.awaitTimer(timersBefore+1), "expected re-probe delay timer")
+	assert.True(t, th.pm.isProbing("myhost.local."), "should re-probe the same name")
+	assert.Equal(t, 0, th.renameCount(), "post-probing conflict must not rename directly")
 
 	close(th.closed)
 	<-th.pm.done
 }
 
-// TestAnnouncementCacheFlushBits verifies that A/AAAA/SRV/TXT records have
-// the cache-flush bit set, while PTR records do not.
+// TestAnnouncementCacheFlushBits verifies that unique A/AAAA/SRV/TXT
+// records have the cache-flush bit set, while the shared PTR does not.
 func TestAnnouncementCacheFlushBits(t *testing.T) {
 	dnsName, _ := dnsmessage.NewName("myhost.local.")
 	ptrName, _ := dnsmessage.NewName("_http._tcp.local.")
 	svcName, _ := dnsmessage.NewName("My Svc._http._tcp.local.")
 
-	records := []dnsmessage.Resource{
+	unique := []dnsmessage.Resource{
 		{
 			Header: dnsmessage.ResourceHeader{Name: dnsName, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: 120},
 			Body:   &dnsmessage.AResource{A: [4]byte{1, 2, 3, 4}},
@@ -1163,13 +1199,15 @@ func TestAnnouncementCacheFlushBits(t *testing.T) {
 			Header: dnsmessage.ResourceHeader{Name: svcName, Type: dnsmessage.TypeTXT, Class: dnsmessage.ClassINET, TTL: 120},
 			Body:   &dnsmessage.TXTResource{TXT: []string{"k=v"}},
 		},
+	}
+	shared := []dnsmessage.Resource{
 		{
 			Header: dnsmessage.ResourceHeader{Name: ptrName, Type: dnsmessage.TypePTR, Class: dnsmessage.ClassINET, TTL: 4500},
 			Body:   &dnsmessage.PTRResource{PTR: svcName},
 		},
 	}
 
-	raw, err := buildAnnouncement(records)
+	raw, err := buildAnnouncement(unique, shared)
 	require.NoError(t, err)
 
 	var msg dnsmessage.Message
@@ -1365,6 +1403,216 @@ func TestResponseForUnrelatedName(t *testing.T) {
 	th.awaitTimer(2)
 	assert.Equal(t, 0, th.renameCount(), "unrelated name should not trigger conflict")
 	assert.True(t, th.pm.isProbing("myhost.local."))
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// testSRVRecord builds an SRV record for a service instance.
+func testSRVRecord(instance, target string) dnsmessage.Resource {
+	instName, _ := dnsmessage.NewName(instance)
+	targetName, _ := dnsmessage.NewName(target)
+
+	return dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{
+			Name:  instName,
+			Type:  dnsmessage.TypeSRV,
+			Class: dnsmessage.ClassINET,
+			TTL:   120,
+		},
+		Body: &dnsmessage.SRVResource{Port: 8080, Target: targetName},
+	}
+}
+
+// testPTRRecord builds a shared PTR record: service type → instance.
+func testPTRRecord(serviceType, instance string) dnsmessage.Resource {
+	typeName, _ := dnsmessage.NewName(serviceType)
+	instName, _ := dnsmessage.NewName(instance)
+
+	return dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{
+			Name:  typeName,
+			Type:  dnsmessage.TypePTR,
+			Class: dnsmessage.ClassINET,
+			TTL:   4500,
+		},
+		Body: &dnsmessage.PTRResource{PTR: instName},
+	}
+}
+
+// TestAnnounceIncludesSharedPTR verifies that announcements carry the
+// shared PTR record (no cache-flush) alongside the unique records, while
+// probe queries carry only the unique records.
+func TestAnnounceIncludesSharedPTR(t *testing.T) {
+	th := newTestHarness()
+
+	const instance = "My Service._http._tcp.local."
+	srvRec := testSRVRecord(instance, "myhost.local.")
+	ptrRec := testPTRRecord("_http._tcp.local.", instance)
+	th.pm.addSession(instance, []dnsmessage.Resource{srvRec}, false, ptrRec)
+
+	th.driveToAnnouncing(t)
+
+	// Probe queries must not contain the shared PTR.
+	th.cond.L.Lock()
+	rawProbe := th.questions[0]
+	rawAnnounce := th.answers[0]
+	th.cond.L.Unlock()
+
+	var probe dnsmessage.Message
+	require.NoError(t, probe.Unpack(rawProbe))
+	require.Len(t, probe.Authorities, 1, "probe authority: unique records only")
+	assert.Equal(t, dnsmessage.TypeSRV, probe.Authorities[0].Header.Type)
+
+	var announce dnsmessage.Message
+	require.NoError(t, announce.Unpack(rawAnnounce))
+	require.Len(t, announce.Answers, 2, "announcement: SRV + shared PTR")
+
+	assert.Equal(t, dnsmessage.TypeSRV, announce.Answers[0].Header.Type)
+	assert.NotZero(t, announce.Answers[0].Header.Class&rrClassCacheFlush, "unique SRV gets cache-flush")
+
+	assert.Equal(t, dnsmessage.TypePTR, announce.Answers[1].Header.Type)
+	assert.Zero(t, announce.Answers[1].Header.Class&rrClassCacheFlush, "shared PTR must not cache-flush")
+
+	ptrBody, ok := announce.Answers[1].Body.(*dnsmessage.PTRResource)
+	require.True(t, ok)
+	assert.True(t, strings.EqualFold(instance, ptrBody.PTR.String()), "PTR targets the instance")
+
+	close(th.closed)
+	<-th.pm.done
+}
+
+// TestRenameRetargetsSharedPTR verifies that renaming a session rewrites
+// unique record headers and the shared PTR's target, but not the PTR's
+// header (which names the service type).
+func TestRenameRetargetsSharedPTR(t *testing.T) {
+	th := newTestHarness()
+
+	const instance = "My Service._http._tcp.local."
+	srvRec := testSRVRecord(instance, "myhost.local.")
+	ptrRec := testPTRRecord("_http._tcp.local.", instance)
+
+	sess := &probeSession{
+		name:     instance,
+		baseName: instance,
+		records:  []dnsmessage.Resource{srvRec},
+		shared:   []dnsmessage.Resource{ptrRec},
+	}
+
+	const renamed = "My Service (2)._http._tcp.local."
+	th.pm.renameSession(sess, renamed)
+
+	assert.Equal(t, renamed, sess.name)
+	assert.Equal(t, renamed, sess.records[0].Header.Name.String(), "unique header renamed")
+	assert.Equal(t, "_http._tcp.local.", sess.shared[0].Header.Name.String(), "PTR header unchanged")
+
+	ptrBody, ok := sess.shared[0].Body.(*dnsmessage.PTRResource)
+	require.True(t, ok)
+	assert.Equal(t, renamed, ptrBody.PTR.String(), "PTR target retargeted")
+}
+
+// TestReProbeRateLimitBackoff verifies that post-probing conflicts respect
+// the §8.1 rate limit when scheduling the re-probe.
+func TestReProbeRateLimitBackoff(t *testing.T) {
+	th := newTestHarness()
+	now := th.clock
+
+	sess := &probeSession{
+		name:    "myhost.local.",
+		state:   probeStateEstablished,
+		records: []dnsmessage.Resource{testARecord("myhost.local.")},
+	}
+
+	// Fill the rate window to the limit.
+	for range conflictRateLimit {
+		sess.conflictTimes = append(sess.conflictTimes, now)
+	}
+
+	th.pm.mu.Lock()
+	th.pm.handleReProbe(sess, now)
+	th.pm.mu.Unlock()
+
+	assert.Equal(t, probeStateDelay, sess.state, "session resets to probing")
+	assert.Equal(t, "myhost.local.", sess.name, "name unchanged")
+	assert.Equal(t, now.Add(probeDelay+conflictBackoff), sess.nextEvent, "backoff applied")
+}
+
+// TestReProbeGiveUp verifies that sustained post-probing conflicts stop the
+// session entirely.
+func TestReProbeGiveUp(t *testing.T) {
+	th := newTestHarness()
+	now := th.clock
+
+	sess := &probeSession{
+		name:          "myhost.local.",
+		state:         probeStateEstablished,
+		records:       []dnsmessage.Resource{testARecord("myhost.local.")},
+		conflictCount: conflictRateLimit + 1,
+		firstConflict: now.Add(-conflictGiveUp - time.Second),
+	}
+
+	th.pm.mu.Lock()
+	th.pm.handleReProbe(sess, now)
+	th.pm.mu.Unlock()
+
+	assert.Equal(t, probeStateStopped, sess.state, "session gives up after sustained conflicts")
+}
+
+// TestCustomRenameBecomesBase verifies that a user-supplied rename becomes
+// the base for subsequent default renames.
+func TestCustomRenameBecomesBase(t *testing.T) {
+	th := newTestHarness()
+
+	first := true
+	th.pm.conflictHandler = func(ConflictEvent) ConflictAction {
+		if first {
+			first = false
+
+			return ConflictAction{Rename: "custom.local."}
+		}
+
+		return ConflictAction{} // fall back to default rename.
+	}
+
+	rec := testARecord("myhost.local.")
+	th.pm.addSession("myhost.local.", []dnsmessage.Resource{rec}, true)
+	th.driveToProbing(t)
+
+	conflict := func(name string) {
+		n, _ := dnsmessage.NewName(name)
+		th.pm.handleMessage(&dnsmessage.Message{
+			Header: dnsmessage.Header{Response: true},
+			Answers: []dnsmessage.Resource{{
+				Header: dnsmessage.ResourceHeader{Name: n, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: 120},
+				Body:   &dnsmessage.AResource{A: [4]byte{10, 0, 0, 1}},
+			}},
+		})
+	}
+
+	// First conflict → custom rename.
+	conflict("myhost.local.")
+	th.advance(probeDelay)
+	require.True(t, th.awaitRenames(1))
+	assert.True(t, th.pm.isProbing("custom.local."))
+
+	// Drive the renamed session into probing, then conflict again.
+	ft := th.awaitTimer(2)
+	require.NotNil(t, ft)
+	th.advance(probeDelay)
+	ft.fire()
+	require.True(t, th.await(func() bool { return len(th.questions) >= 2 }),
+		"expected probe for custom name")
+
+	conflict("custom.local.")
+	th.advance(probeDelay)
+	require.True(t, th.awaitRenames(2))
+
+	th.cond.L.Lock()
+	second := th.renames[1]
+	th.cond.L.Unlock()
+	assert.Equal(t, "custom.local.", second.oldName)
+	// Default rename derives from the custom base: count=2 → suffix 3.
+	assert.Equal(t, "custom-3.local.", second.newName)
 
 	close(th.closed)
 	<-th.pm.done

--- a/probe_test.go
+++ b/probe_test.go
@@ -1305,13 +1305,13 @@ func TestConflictRenameAnnounce(t *testing.T) {
 	require.True(t, th.awaitRenames(1))
 
 	// Drive renamed session: delay, 3 probes, transition, 2 announcements.
-	fire(probeDelay)                         // delay → first re-probe
-	fire(probeInterval)                      // second re-probe
-	fire(probeInterval)                      // third re-probe
-	fire(probeInterval)                      // transition to announcing
-	require.True(t, th.awaitAnswers(1))      // first announcement
-	fire(announceInterval)                   // second announcement
-	require.True(t, th.awaitAnswers(2))      // established
+	fire(probeDelay)    // delay, first re-probe
+	fire(probeInterval) // second re-probe
+	fire(probeInterval) // third re-probe
+	fire(probeInterval) // transition to announcing
+	require.True(t, th.awaitAnswers(1))
+	fire(announceInterval) // second announcement
+	require.True(t, th.awaitAnswers(2))
 	<-th.pm.ready
 
 	// Unpack the first announcement and verify wire content.

--- a/probe_test.go
+++ b/probe_test.go
@@ -900,7 +900,7 @@ func TestShouldBackoff(t *testing.T) {
 	session := &probeSession{name: "test.local."}
 
 	// Fill conflict times within the rate window.
-	for i := 0; i < conflictRateLimit-1; i++ {
+	for i := range conflictRateLimit - 1 {
 		session.conflictTimes = append(session.conflictTimes, now.Add(time.Duration(i)*time.Second))
 	}
 

--- a/server.go
+++ b/server.go
@@ -124,6 +124,12 @@ type answerWriter interface {
 	writeAnswer(ifIndex int, b []byte, hasLoopbackData, hasIPv6Zone bool, unicastDst *net.UDPAddr)
 }
 
+// probeChecker is used by questionHandler to check whether a name is
+// currently being probed (and should not be answered yet).
+type probeChecker interface {
+	isProbing(name string) bool
+}
+
 // server handles mDNS server operations (responding to queries).
 type server struct {
 	log     logging.LeveledLogger
@@ -131,9 +137,11 @@ type server struct {
 	handler *questionHandler
 	writer  answerWriter
 	ttl     uint32
+	probes  *probeManager
 
-	mu       sync.RWMutex
-	services []ServiceInstance
+	mu         sync.RWMutex
+	services   []ServiceInstance
+	localNames []string
 }
 
 // newServer creates a new mDNS server.
@@ -151,18 +159,18 @@ func newServer(
 	allowedRecordTypes []dnsmessage.Type,
 ) *server {
 	srv := &server{
-		log:      log,
-		name:     name,
-		writer:   writer,
-		ttl:      ttl,
-		services: services,
+		log:        log,
+		name:       name,
+		writer:     writer,
+		ttl:        ttl,
+		services:   services,
+		localNames: localNames,
 	}
 	srv.handler = newQuestionHandler(
-		localNames,
 		localAddress,
 		ifaces,
 		hasIPv4,
-		srv, // server implements answerSender
+		srv, // server implements answerSender + getLocalNames
 		writer,
 		log,
 		name,
@@ -172,6 +180,42 @@ func newServer(
 	)
 
 	return srv
+}
+
+// onProbeRenamed is the callback invoked by probeManager when a name is
+// renamed due to conflict. It updates the server's localNames and services.
+func (s *server) onProbeRenamed(oldName, newName string, isHost bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if isHost {
+		for i, name := range s.localNames {
+			if strings.EqualFold(name, oldName) {
+				s.localNames[i] = newName
+			}
+		}
+		// Update host references in services.
+		for i := range s.services {
+			if strings.EqualFold(s.services[i].Host, oldName) {
+				s.services[i].Host = newName
+			}
+		}
+	} else {
+		// Service instance rename: the FQDN changed but instance name
+		// is encoded inside. Update the Instance field.
+		for i := range s.services {
+			oldFQDN := s.services[i].serviceInstanceName()
+			if strings.EqualFold(oldFQDN, oldName) {
+				// Extract new instance name from FQDN.
+				svcName := s.services[i].serviceName()
+				newInstance := strings.TrimSuffix(newName, "."+svcName)
+				newInstance = strings.TrimSuffix(newInstance, ".")
+				// Unescape dots for storage.
+				newInstance = strings.ReplaceAll(newInstance, "\\.", ".")
+				s.services[i].Instance = newInstance
+			}
+		}
+	}
 }
 
 // registerService adds a DNS-SD service to the server.
@@ -203,6 +247,17 @@ func (s *server) getServices() []ServiceInstance {
 
 	out := make([]ServiceInstance, len(s.services))
 	copy(out, s.services)
+
+	return out
+}
+
+// getLocalNames returns a snapshot of local names.
+func (s *server) getLocalNames() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]string, len(s.localNames))
+	copy(out, s.localNames)
 
 	return out
 }
@@ -278,6 +333,14 @@ type serverConfig struct {
 	// refreshCheckInterval is how often the refresh loop checks for
 	// records due for refresh. Zero means use defaultRefreshCheckInterval.
 	refreshCheckInterval time.Duration
+
+	// probing controls whether RFC 6762 §8 name probing is enabled.
+	// nil = default (true for NewServer, false for legacy Server).
+	probing *bool
+
+	// conflictHandler is an optional user callback invoked when a naming
+	// conflict is detected during probing (RFC 6762 §9).
+	conflictHandler func(ConflictEvent) ConflictAction
 }
 
 // NewServer creates a new mDNS server with the given options.
@@ -548,6 +611,29 @@ func NewServer(
 		cfg.allowedRecordTypes,
 	)
 
+	// Set up probing (RFC 6762 §8).
+	probingEnabled := cfg.probing == nil || *cfg.probing
+	if probingEnabled {
+		if cfg.conflictHandler != nil {
+			conn.setConflictHandler(cfg.conflictHandler)
+		}
+
+		conn.server.probes = newProbeManager(
+			conn, // questionWriter
+			conn, // answerWriter
+			log,
+			conn.name,
+			cfg.responseTTL,
+			conn.conflictHandler,
+			conn.server.onProbeRenamed,
+		)
+		conn.server.handler.probeChecker = conn.server.probes
+
+		// Register sessions for all names that need probing.
+		buildProbeSessions(conn.server.probes, localNames, cfg.services, ifacesToUse, cfg.responseTTL,
+			multicastPktConnV4 != nil, multicastPktConnV6 != nil, cfg.localAddress)
+	}
+
 	if cfg.includeLoopback {
 		// Enable loopback for efficient self-messaging without going through the network stack.
 		enableLoopback4(multicastPktConnV4, conn.name, "multicast", log)
@@ -565,6 +651,124 @@ func NewServer(
 	<-started
 
 	return conn, nil
+}
+
+// buildProbeSessions registers probe sessions for all names that need probing.
+//
+//nolint:cyclop
+func buildProbeSessions(
+	pm *probeManager,
+	localNames []string,
+	services []ServiceInstance,
+	ifaces map[int]netInterface,
+	ttl uint32,
+	hasIPv4, hasIPv6 bool,
+	localAddress net.IP,
+) {
+	// Probe hostnames: collect A/AAAA records for each local name.
+	for _, name := range localNames {
+		records := buildHostProbeRecords(name, ifaces, ttl, hasIPv4, hasIPv6, localAddress)
+
+		if len(records) > 0 {
+			pm.addSession(name, records, true)
+		}
+	}
+
+	// Probe service instance names: SRV + TXT records.
+	for i := range services {
+		svc := &services[i]
+		instanceName := svc.serviceInstanceName()
+
+		var records []dnsmessage.Resource
+
+		srvRec, err := buildSRVResource(instanceName, svc.Host, svc.Port, svc.Priority, svc.Weight, ttl)
+		if err == nil {
+			records = append(records, srvRec)
+		}
+
+		txtStrings, err := encodeTXTRecordStrings(svc.Text)
+		if err == nil {
+			txtRec, err := buildTXTResource(instanceName, txtStrings, ttl)
+			if err == nil {
+				records = append(records, txtRec)
+			}
+		}
+
+		if len(records) > 0 {
+			pm.addSession(instanceName, records, false)
+		}
+	}
+}
+
+// addrToResource builds an A or AAAA resource for the given address.
+// It returns false if the address family is not enabled or the record cannot be built.
+func addrToResource(name string, addr netip.Addr, ttl uint32, hasIPv4, hasIPv6 bool) (dnsmessage.Resource, bool) {
+	if addr.Is4() && hasIPv4 {
+		rec, err := buildAResource(name, addr, ttl)
+
+		return rec, err == nil
+	}
+
+	if addr.Is6() && hasIPv6 {
+		rec, err := buildAAAAResource(name, addr, ttl)
+
+		return rec, err == nil
+	}
+
+	return dnsmessage.Resource{}, false
+}
+
+// buildHostProbeRecords creates the proposed A/AAAA records for a hostname.
+// When localAddress is set, only that address is used; otherwise interface
+// addresses are collected.
+func buildHostProbeRecords(
+	name string,
+	ifaces map[int]netInterface,
+	ttl uint32,
+	hasIPv4, hasIPv6 bool,
+	localAddress net.IP,
+) []dnsmessage.Resource {
+	if localAddress != nil {
+		return buildLocalAddrRecords(name, ttl, hasIPv4, hasIPv6, localAddress)
+	}
+
+	var records []dnsmessage.Resource
+
+	for _, ifc := range ifaces {
+		for _, addr := range ifc.ipAddrs {
+			a := addr.Unmap()
+			if a.Is4In6() {
+				continue
+			}
+
+			if rec, ok := addrToResource(name, a, ttl, hasIPv4, hasIPv6); ok {
+				records = append(records, rec)
+			}
+		}
+	}
+
+	return records
+}
+
+// buildLocalAddrRecords builds A/AAAA records for a single explicit local address.
+func buildLocalAddrRecords(
+	name string,
+	ttl uint32,
+	hasIPv4, hasIPv6 bool,
+	localAddress net.IP,
+) []dnsmessage.Resource {
+	addr, ok := netip.AddrFromSlice(localAddress)
+	if !ok {
+		return nil
+	}
+
+	addr = addr.Unmap()
+
+	if rec, ok := addrToResource(name, addr, ttl, hasIPv4, hasIPv6); ok {
+		return []dnsmessage.Resource{rec}
+	}
+
+	return nil
 }
 
 // Server establishes a mDNS connection over an existing conn.
@@ -598,6 +802,8 @@ func Server(
 		WithRecordTypes(dnsmessage.TypeA, dnsmessage.TypeAAAA),
 		// Legacy behavior: no proactive cache refresh.
 		WithCacheRefresh(false),
+		// Legacy names are UUIDs, unique by construction — no probing needed.
+		WithProbing(false),
 	}
 	if config.Name != "" {
 		opts = append(opts, WithName(config.Name))
@@ -785,12 +991,12 @@ type answerSender interface {
 		svc *ServiceInstance, addr netip.Addr, dst *net.UDPAddr, isUnicast bool,
 	)
 	getServices() []ServiceInstance
+	getLocalNames() []string
 }
 
 // questionHandler processes incoming mDNS questions (server role).
 // It matches questions against configured local names and sends answers.
 type questionHandler struct {
-	localNames         []string
 	localAddress       net.IP
 	ifaces             map[int]netInterface
 	hasIPv4            bool
@@ -801,11 +1007,11 @@ type questionHandler struct {
 	dstAddr4           *net.UDPAddr
 	dstAddr6           *net.UDPAddr
 	allowedRecordTypes []dnsmessage.Type
+	probeChecker       probeChecker
 }
 
 // newQuestionHandler creates a new questionHandler.
 func newQuestionHandler(
-	localNames []string,
 	localAddress net.IP,
 	ifaces map[int]netInterface,
 	hasIPv4 bool,
@@ -817,7 +1023,6 @@ func newQuestionHandler(
 	allowedRecordTypes []dnsmessage.Type,
 ) *questionHandler {
 	return &questionHandler{
-		localNames:         localNames,
 		localAddress:       localAddress,
 		ifaces:             ifaces,
 		hasIPv4:            hasIPv4,
@@ -849,6 +1054,11 @@ func (h *questionHandler) isRecordTypeAllowed(qtype dnsmessage.Type) bool {
 func (h *questionHandler) handle(ctx *messageContext, msg *dnsmessage.Message) {
 	for _, question := range msg.Questions {
 		if !h.isRecordTypeAllowed(question.Type) {
+			continue
+		}
+
+		// Skip responding for names currently being probed (§8.1).
+		if h.probeChecker != nil && h.probeChecker.isProbing(question.Name.String()) {
 			continue
 		}
 
@@ -886,7 +1096,7 @@ func (h *questionHandler) handleAddressQuestion(
 ) {
 	queryWantsV4 := question.Type == dnsmessage.TypeA
 
-	for _, localName := range h.localNames {
+	for _, localName := range h.sender.getLocalNames() {
 		if !strings.EqualFold(localName, question.Name.String()) {
 			continue
 		}

--- a/server.go
+++ b/server.go
@@ -623,7 +623,6 @@ func NewServer(
 			conn, // answerWriter
 			log,
 			conn.name,
-			cfg.responseTTL,
 			conn.conflictHandler,
 			conn.server.onProbeRenamed,
 		)
@@ -674,7 +673,8 @@ func buildProbeSessions(
 		}
 	}
 
-	// Probe service instance names: SRV + TXT records.
+	// Probe service instance names: SRV + TXT are the unique records; the
+	// service-type PTR is shared (announced per §8.3, never probed).
 	for i := range services {
 		svc := &services[i]
 		instanceName := svc.serviceInstanceName()
@@ -694,7 +694,13 @@ func buildProbeSessions(
 			}
 		}
 
-		if len(records) > 0 {
+		if len(records) == 0 {
+			continue
+		}
+
+		if ptrRec, err := buildPTRResource(svc.serviceName(), instanceName, browseTTL); err == nil {
+			pm.addSession(instanceName, records, false, ptrRec)
+		} else {
 			pm.addSession(instanceName, records, false)
 		}
 	}
@@ -736,12 +742,7 @@ func buildHostProbeRecords(
 
 	for _, ifc := range ifaces {
 		for _, addr := range ifc.ipAddrs {
-			a := addr.Unmap()
-			if a.Is4In6() {
-				continue
-			}
-
-			if rec, ok := addrToResource(name, a, ttl, hasIPv4, hasIPv6); ok {
+			if rec, ok := addrToResource(name, addr.Unmap(), ttl, hasIPv4, hasIPv6); ok {
 				records = append(records, rec)
 			}
 		}
@@ -1053,7 +1054,8 @@ func (h *questionHandler) isRecordTypeAllowed(qtype dnsmessage.Type) bool {
 //nolint:gocognit,gocyclo,cyclop
 func (h *questionHandler) handle(ctx *messageContext, msg *dnsmessage.Message) {
 	for _, question := range msg.Questions {
-		if !h.isRecordTypeAllowed(question.Type) {
+		// ANY queries are filtered per concrete type in handleAnyQuestion.
+		if question.Type != typeANY && !h.isRecordTypeAllowed(question.Type) {
 			continue
 		}
 
@@ -1083,9 +1085,41 @@ func (h *questionHandler) handle(ctx *messageContext, msg *dnsmessage.Message) {
 			h.handlePTRQuestion(ctx, msg.Header.ID, question, dst, shouldReplyUnicast)
 		case dnsmessage.TypeSRV, dnsmessage.TypeTXT:
 			h.handleServiceRecordQuestion(ctx, msg.Header.ID, question, dst, shouldReplyUnicast)
+		case typeANY:
+			h.handleAnyQuestion(ctx, msg.Header.ID, question, dst, shouldReplyUnicast)
 		default:
 			continue
 		}
+	}
+}
+
+// handleAnyQuestion answers a qtype ANY (255) question with all record
+// types matching the name (RFC 6762 §6). This also defends established
+// names against probes from other hosts (§8.1): a prober that receives our
+// answer treats the name as taken and renames itself.
+func (h *questionHandler) handleAnyQuestion(
+	ctx *messageContext, queryID uint16, question dnsmessage.Question,
+	dst *net.UDPAddr, isUnicast bool,
+) {
+	dispatch := []struct {
+		qtype   dnsmessage.Type
+		handler func(*messageContext, uint16, dnsmessage.Question, *net.UDPAddr, bool)
+	}{
+		{dnsmessage.TypeA, h.handleAddressQuestion},
+		{dnsmessage.TypeAAAA, h.handleAddressQuestion},
+		{dnsmessage.TypeSRV, h.handleServiceRecordQuestion},
+		{dnsmessage.TypeTXT, h.handleServiceRecordQuestion},
+		{dnsmessage.TypePTR, h.handlePTRQuestion},
+	}
+
+	for _, d := range dispatch {
+		if !h.isRecordTypeAllowed(d.qtype) {
+			continue
+		}
+
+		typedQuestion := question
+		typedQuestion.Type = d.qtype
+		d.handler(ctx, queryID, typedQuestion, dst, isUnicast)
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -219,10 +219,30 @@ func (s *server) onProbeRenamed(oldName, newName string, isHost bool) {
 				newInstance = strings.TrimSuffix(newInstance, ".")
 				// Unescape dots for storage.
 				newInstance = strings.ReplaceAll(newInstance, "\\.", ".")
+				oldInstance := s.services[i].Instance
 				s.services[i].Instance = newInstance
+				s.rekeyTXTGenerationLocked(oldInstance, newInstance, s.services[i].Service)
 			}
 		}
 	}
+}
+
+// rekeyTXTGenerationLocked moves a pending TXT announcement generation to
+// follow a probe rename, so the repeat announcement still finds the service
+// and no stale entry is left behind. Caller must hold s.mu.
+func (s *server) rekeyTXTGenerationLocked(oldInstance, newInstance, service string) {
+	if oldInstance == newInstance || s.txtAnnouncementGenerations == nil {
+		return
+	}
+
+	oldKey := registeredServiceKey{instance: oldInstance, service: service}
+	generation, ok := s.txtAnnouncementGenerations[oldKey]
+	if !ok {
+		return
+	}
+
+	delete(s.txtAnnouncementGenerations, oldKey)
+	s.txtAnnouncementGenerations[registeredServiceKey{instance: newInstance, service: service}] = generation
 }
 
 // registerService adds a DNS-SD service to the server.
@@ -271,7 +291,13 @@ func (s *server) updateTXT(instance, service string, text []TXTEntry) (uint64, e
 		s.txtAnnouncementGenerations[registeredServiceKey{instance: instance, service: service}] = generation
 
 		s.services[i] = updated
-		s.writer.writeAnswer(-1, rawAnnouncement, false, false, nil)
+
+		// A name still being probed has not been claimed yet, so it must
+		// not be announced (RFC 6762 §8.2). The announcement that follows a
+		// successful probe carries the TXT data stored above.
+		if !s.isProbingLocked(updated.serviceInstanceName()) {
+			s.writer.writeAnswer(-1, rawAnnouncement, false, false, nil)
+		}
 
 		return generation, nil
 	}
@@ -279,17 +305,25 @@ func (s *server) updateTXT(instance, service string, text []TXTEntry) (uint64, e
 	return 0, errServiceNotFound
 }
 
-func (s *server) repeatTXTAnnouncement(instance, service string, generation uint64) error {
+// repeatTXTAnnouncement sends the second announcement for a TXT update
+// (RFC 6762 §8.3). The service is located by announcement generation
+// rather than by name, because probing may have renamed the instance
+// since updateTXT captured it (§9).
+func (s *server) repeatTXTAnnouncement(generation uint64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	key := registeredServiceKey{instance: instance, service: service}
-	if s.txtAnnouncementGenerations[key] != generation {
+	key, ok := s.keyForGenerationLocked(generation)
+	if !ok {
 		return nil
 	}
+
 	for i := range s.services {
-		if s.services[i].Instance != instance || s.services[i].Service != service {
+		if s.services[i].Instance != key.instance || s.services[i].Service != key.service {
 			continue
+		}
+		if s.isProbingLocked(s.services[i].serviceInstanceName()) {
+			return nil
 		}
 
 		txtStrings, err := encodeTXTRecordStrings(s.services[i].Text)
@@ -306,6 +340,25 @@ func (s *server) repeatTXTAnnouncement(instance, service string, generation uint
 	}
 
 	return nil
+}
+
+// keyForGenerationLocked returns the service key currently associated with
+// the given TXT announcement generation. Caller must hold s.mu.
+func (s *server) keyForGenerationLocked(generation uint64) (registeredServiceKey, bool) {
+	for key, gen := range s.txtAnnouncementGenerations {
+		if gen == generation {
+			return key, true
+		}
+	}
+
+	return registeredServiceKey{}, false
+}
+
+// isProbingLocked reports whether the given name is still being probed.
+// A responder must not announce records for an unverified name
+// (RFC 6762 §8.2). Caller must hold s.mu.
+func (s *server) isProbingLocked(name string) bool {
+	return s.probes != nil && s.probes.isProbing(name)
 }
 
 func (s *server) packTXTAnnouncement(svc *ServiceInstance, txtStrings []string) ([]byte, error) {

--- a/server.go
+++ b/server.go
@@ -124,6 +124,12 @@ type answerWriter interface {
 	writeAnswer(ifIndex int, b []byte, hasLoopbackData, hasIPv6Zone bool, unicastDst *net.UDPAddr)
 }
 
+// probeChecker is used by questionHandler to check whether a name is
+// currently being probed (and should not be answered yet).
+type probeChecker interface {
+	isProbing(name string) bool
+}
+
 // server handles mDNS server operations (responding to queries).
 type server struct {
 	log     logging.LeveledLogger
@@ -131,9 +137,11 @@ type server struct {
 	handler *questionHandler
 	writer  answerWriter
 	ttl     uint32
+	probes  *probeManager
 
 	mu                         sync.RWMutex
 	services                   []ServiceInstance
+	localNames                 []string
 	txtAnnouncementGeneration  uint64
 	txtAnnouncementGenerations map[registeredServiceKey]uint64
 }
@@ -158,18 +166,18 @@ func newServer(
 	allowedRecordTypes []dnsmessage.Type,
 ) *server {
 	srv := &server{
-		log:      log,
-		name:     name,
-		writer:   writer,
-		ttl:      ttl,
-		services: services,
+		log:        log,
+		name:       name,
+		writer:     writer,
+		ttl:        ttl,
+		services:   services,
+		localNames: localNames,
 	}
 	srv.handler = newQuestionHandler(
-		localNames,
 		localAddress,
 		ifaces,
 		hasIPv4,
-		srv, // server implements answerSender
+		srv, // server implements answerSender + getLocalNames
 		writer,
 		log,
 		name,
@@ -179,6 +187,42 @@ func newServer(
 	)
 
 	return srv
+}
+
+// onProbeRenamed is the callback invoked by probeManager when a name is
+// renamed due to conflict. It updates the server's localNames and services.
+func (s *server) onProbeRenamed(oldName, newName string, isHost bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if isHost {
+		for i, name := range s.localNames {
+			if strings.EqualFold(name, oldName) {
+				s.localNames[i] = newName
+			}
+		}
+		// Update host references in services.
+		for i := range s.services {
+			if strings.EqualFold(s.services[i].Host, oldName) {
+				s.services[i].Host = newName
+			}
+		}
+	} else {
+		// Service instance rename: the FQDN changed but instance name
+		// is encoded inside. Update the Instance field.
+		for i := range s.services {
+			oldFQDN := s.services[i].serviceInstanceName()
+			if strings.EqualFold(oldFQDN, oldName) {
+				// Extract new instance name from FQDN.
+				svcName := s.services[i].serviceName()
+				newInstance := strings.TrimSuffix(newName, "."+svcName)
+				newInstance = strings.TrimSuffix(newInstance, ".")
+				// Unescape dots for storage.
+				newInstance = strings.ReplaceAll(newInstance, "\\.", ".")
+				s.services[i].Instance = newInstance
+			}
+		}
+	}
 }
 
 // registerService adds a DNS-SD service to the server.
@@ -303,6 +347,17 @@ func (s *server) getServices() []ServiceInstance {
 	return out
 }
 
+// getLocalNames returns a snapshot of local names.
+func (s *server) getLocalNames() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]string, len(s.localNames))
+	copy(out, s.localNames)
+
+	return out
+}
+
 // sendAnswer implements answerSender interface.
 func (s *server) sendAnswer(
 	queryID uint16, question dnsmessage.Question, ifIndex int,
@@ -374,6 +429,14 @@ type serverConfig struct {
 	// refreshCheckInterval is how often the refresh loop checks for
 	// records due for refresh. Zero means use defaultRefreshCheckInterval.
 	refreshCheckInterval time.Duration
+
+	// probing controls whether RFC 6762 §8 name probing is enabled.
+	// nil = default (true for NewServer, false for legacy Server).
+	probing *bool
+
+	// conflictHandler is an optional user callback invoked when a naming
+	// conflict is detected during probing (RFC 6762 §9).
+	conflictHandler func(ConflictEvent) ConflictAction
 }
 
 // NewServer creates a new mDNS server with the given options.
@@ -644,6 +707,29 @@ func NewServer(
 		cfg.allowedRecordTypes,
 	)
 
+	// Set up probing (RFC 6762 §8).
+	probingEnabled := cfg.probing == nil || *cfg.probing
+	if probingEnabled {
+		if cfg.conflictHandler != nil {
+			conn.setConflictHandler(cfg.conflictHandler)
+		}
+
+		conn.server.probes = newProbeManager(
+			conn, // questionWriter
+			conn, // answerWriter
+			log,
+			conn.name,
+			cfg.responseTTL,
+			conn.conflictHandler,
+			conn.server.onProbeRenamed,
+		)
+		conn.server.handler.probeChecker = conn.server.probes
+
+		// Register sessions for all names that need probing.
+		buildProbeSessions(conn.server.probes, localNames, cfg.services, ifacesToUse, cfg.responseTTL,
+			multicastPktConnV4 != nil, multicastPktConnV6 != nil, cfg.localAddress)
+	}
+
 	if cfg.includeLoopback {
 		// Enable loopback for efficient self-messaging without going through the network stack.
 		enableLoopback4(multicastPktConnV4, conn.name, "multicast", log)
@@ -661,6 +747,124 @@ func NewServer(
 	<-started
 
 	return conn, nil
+}
+
+// buildProbeSessions registers probe sessions for all names that need probing.
+//
+//nolint:cyclop
+func buildProbeSessions(
+	pm *probeManager,
+	localNames []string,
+	services []ServiceInstance,
+	ifaces map[int]netInterface,
+	ttl uint32,
+	hasIPv4, hasIPv6 bool,
+	localAddress net.IP,
+) {
+	// Probe hostnames: collect A/AAAA records for each local name.
+	for _, name := range localNames {
+		records := buildHostProbeRecords(name, ifaces, ttl, hasIPv4, hasIPv6, localAddress)
+
+		if len(records) > 0 {
+			pm.addSession(name, records, true)
+		}
+	}
+
+	// Probe service instance names: SRV + TXT records.
+	for i := range services {
+		svc := &services[i]
+		instanceName := svc.serviceInstanceName()
+
+		var records []dnsmessage.Resource
+
+		srvRec, err := buildSRVResource(instanceName, svc.Host, svc.Port, svc.Priority, svc.Weight, ttl)
+		if err == nil {
+			records = append(records, srvRec)
+		}
+
+		txtStrings, err := encodeTXTRecordStrings(svc.Text)
+		if err == nil {
+			txtRec, err := buildTXTResource(instanceName, txtStrings, ttl)
+			if err == nil {
+				records = append(records, txtRec)
+			}
+		}
+
+		if len(records) > 0 {
+			pm.addSession(instanceName, records, false)
+		}
+	}
+}
+
+// addrToResource builds an A or AAAA resource for the given address.
+// It returns false if the address family is not enabled or the record cannot be built.
+func addrToResource(name string, addr netip.Addr, ttl uint32, hasIPv4, hasIPv6 bool) (dnsmessage.Resource, bool) {
+	if addr.Is4() && hasIPv4 {
+		rec, err := buildAResource(name, addr, ttl)
+
+		return rec, err == nil
+	}
+
+	if addr.Is6() && hasIPv6 {
+		rec, err := buildAAAAResource(name, addr, ttl)
+
+		return rec, err == nil
+	}
+
+	return dnsmessage.Resource{}, false
+}
+
+// buildHostProbeRecords creates the proposed A/AAAA records for a hostname.
+// When localAddress is set, only that address is used; otherwise interface
+// addresses are collected.
+func buildHostProbeRecords(
+	name string,
+	ifaces map[int]netInterface,
+	ttl uint32,
+	hasIPv4, hasIPv6 bool,
+	localAddress net.IP,
+) []dnsmessage.Resource {
+	if localAddress != nil {
+		return buildLocalAddrRecords(name, ttl, hasIPv4, hasIPv6, localAddress)
+	}
+
+	var records []dnsmessage.Resource
+
+	for _, ifc := range ifaces {
+		for _, addr := range ifc.ipAddrs {
+			a := addr.Unmap()
+			if a.Is4In6() {
+				continue
+			}
+
+			if rec, ok := addrToResource(name, a, ttl, hasIPv4, hasIPv6); ok {
+				records = append(records, rec)
+			}
+		}
+	}
+
+	return records
+}
+
+// buildLocalAddrRecords builds A/AAAA records for a single explicit local address.
+func buildLocalAddrRecords(
+	name string,
+	ttl uint32,
+	hasIPv4, hasIPv6 bool,
+	localAddress net.IP,
+) []dnsmessage.Resource {
+	addr, ok := netip.AddrFromSlice(localAddress)
+	if !ok {
+		return nil
+	}
+
+	addr = addr.Unmap()
+
+	if rec, ok := addrToResource(name, addr, ttl, hasIPv4, hasIPv6); ok {
+		return []dnsmessage.Resource{rec}
+	}
+
+	return nil
 }
 
 // Server establishes a mDNS connection over an existing conn.
@@ -694,6 +898,8 @@ func Server(
 		WithRecordTypes(dnsmessage.TypeA, dnsmessage.TypeAAAA),
 		// Legacy behavior: no proactive cache refresh.
 		WithCacheRefresh(false),
+		// Legacy names are UUIDs, unique by construction — no probing needed.
+		WithProbing(false),
 	}
 	if config.Name != "" {
 		opts = append(opts, WithName(config.Name))
@@ -881,12 +1087,12 @@ type answerSender interface {
 		svc *ServiceInstance, addr netip.Addr, dst *net.UDPAddr, isUnicast bool,
 	)
 	getServices() []ServiceInstance
+	getLocalNames() []string
 }
 
 // questionHandler processes incoming mDNS questions (server role).
 // It matches questions against configured local names and sends answers.
 type questionHandler struct {
-	localNames         []string
 	localAddress       net.IP
 	ifaces             map[int]netInterface
 	hasIPv4            bool
@@ -897,11 +1103,11 @@ type questionHandler struct {
 	dstAddr4           *net.UDPAddr
 	dstAddr6           *net.UDPAddr
 	allowedRecordTypes []dnsmessage.Type
+	probeChecker       probeChecker
 }
 
 // newQuestionHandler creates a new questionHandler.
 func newQuestionHandler(
-	localNames []string,
 	localAddress net.IP,
 	ifaces map[int]netInterface,
 	hasIPv4 bool,
@@ -913,7 +1119,6 @@ func newQuestionHandler(
 	allowedRecordTypes []dnsmessage.Type,
 ) *questionHandler {
 	return &questionHandler{
-		localNames:         localNames,
 		localAddress:       localAddress,
 		ifaces:             ifaces,
 		hasIPv4:            hasIPv4,
@@ -945,6 +1150,11 @@ func (h *questionHandler) isRecordTypeAllowed(qtype dnsmessage.Type) bool {
 func (h *questionHandler) handle(ctx *messageContext, msg *dnsmessage.Message) {
 	for _, question := range msg.Questions {
 		if !h.isRecordTypeAllowed(question.Type) {
+			continue
+		}
+
+		// Skip responding for names currently being probed (§8.1).
+		if h.probeChecker != nil && h.probeChecker.isProbing(question.Name.String()) {
 			continue
 		}
 
@@ -982,7 +1192,7 @@ func (h *questionHandler) handleAddressQuestion(
 ) {
 	queryWantsV4 := question.Type == dnsmessage.TypeA
 
-	for _, localName := range h.localNames {
+	for _, localName := range h.sender.getLocalNames() {
 		if !strings.EqualFold(localName, question.Name.String()) {
 			continue
 		}

--- a/server.go
+++ b/server.go
@@ -719,7 +719,6 @@ func NewServer(
 			conn, // answerWriter
 			log,
 			conn.name,
-			cfg.responseTTL,
 			conn.conflictHandler,
 			conn.server.onProbeRenamed,
 		)
@@ -770,7 +769,8 @@ func buildProbeSessions(
 		}
 	}
 
-	// Probe service instance names: SRV + TXT records.
+	// Probe service instance names: SRV + TXT are the unique records; the
+	// service-type PTR is shared (announced per §8.3, never probed).
 	for i := range services {
 		svc := &services[i]
 		instanceName := svc.serviceInstanceName()
@@ -790,7 +790,13 @@ func buildProbeSessions(
 			}
 		}
 
-		if len(records) > 0 {
+		if len(records) == 0 {
+			continue
+		}
+
+		if ptrRec, err := buildPTRResource(svc.serviceName(), instanceName, browseTTL); err == nil {
+			pm.addSession(instanceName, records, false, ptrRec)
+		} else {
 			pm.addSession(instanceName, records, false)
 		}
 	}
@@ -832,12 +838,7 @@ func buildHostProbeRecords(
 
 	for _, ifc := range ifaces {
 		for _, addr := range ifc.ipAddrs {
-			a := addr.Unmap()
-			if a.Is4In6() {
-				continue
-			}
-
-			if rec, ok := addrToResource(name, a, ttl, hasIPv4, hasIPv6); ok {
+			if rec, ok := addrToResource(name, addr.Unmap(), ttl, hasIPv4, hasIPv6); ok {
 				records = append(records, rec)
 			}
 		}
@@ -1149,7 +1150,8 @@ func (h *questionHandler) isRecordTypeAllowed(qtype dnsmessage.Type) bool {
 //nolint:gocognit,gocyclo,cyclop
 func (h *questionHandler) handle(ctx *messageContext, msg *dnsmessage.Message) {
 	for _, question := range msg.Questions {
-		if !h.isRecordTypeAllowed(question.Type) {
+		// ANY queries are filtered per concrete type in handleAnyQuestion.
+		if question.Type != typeANY && !h.isRecordTypeAllowed(question.Type) {
 			continue
 		}
 
@@ -1179,9 +1181,41 @@ func (h *questionHandler) handle(ctx *messageContext, msg *dnsmessage.Message) {
 			h.handlePTRQuestion(ctx, msg.Header.ID, question, dst, shouldReplyUnicast)
 		case dnsmessage.TypeSRV, dnsmessage.TypeTXT:
 			h.handleServiceRecordQuestion(ctx, msg.Header.ID, question, dst, shouldReplyUnicast)
+		case typeANY:
+			h.handleAnyQuestion(ctx, msg.Header.ID, question, dst, shouldReplyUnicast)
 		default:
 			continue
 		}
+	}
+}
+
+// handleAnyQuestion answers a qtype ANY (255) question with all record
+// types matching the name (RFC 6762 §6). This also defends established
+// names against probes from other hosts (§8.1): a prober that receives our
+// answer treats the name as taken and renames itself.
+func (h *questionHandler) handleAnyQuestion(
+	ctx *messageContext, queryID uint16, question dnsmessage.Question,
+	dst *net.UDPAddr, isUnicast bool,
+) {
+	dispatch := []struct {
+		qtype   dnsmessage.Type
+		handler func(*messageContext, uint16, dnsmessage.Question, *net.UDPAddr, bool)
+	}{
+		{dnsmessage.TypeA, h.handleAddressQuestion},
+		{dnsmessage.TypeAAAA, h.handleAddressQuestion},
+		{dnsmessage.TypeSRV, h.handleServiceRecordQuestion},
+		{dnsmessage.TypeTXT, h.handleServiceRecordQuestion},
+		{dnsmessage.TypePTR, h.handlePTRQuestion},
+	}
+
+	for _, d := range dispatch {
+		if !h.isRecordTypeAllowed(d.qtype) {
+			continue
+		}
+
+		typedQuestion := question
+		typedQuestion.Type = d.qtype
+		d.handler(ctx, queryID, typedQuestion, dst, isUnicast)
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -130,7 +130,9 @@ func TestMultipleOptionsApplied(t *testing.T) {
 	ip := net.ParseIP("10.0.0.1")
 	ifaces := []net.Interface{{Index: 1, Name: "eth0"}}
 
-	// Apply multiple options
+	conflictFn := func(ConflictEvent) ConflictAction { return ConflictAction{Stop: true} }
+
+	// Apply multiple options.
 	opts := []ServerOption{
 		WithName("multi-test"),
 		WithLoggerFactory(factory),
@@ -140,6 +142,7 @@ func TestMultipleOptionsApplied(t *testing.T) {
 		WithInterfaces(ifaces...),
 		WithRecordTypes(dnsmessage.TypeA),
 		WithResponseTTL(300),
+		WithConflictHandler(conflictFn),
 	}
 
 	for _, opt := range opts {
@@ -155,6 +158,7 @@ func TestMultipleOptionsApplied(t *testing.T) {
 	assert.Equal(t, ifaces, cfg.interfaces)
 	assert.Equal(t, []dnsmessage.Type{dnsmessage.TypeA}, cfg.allowedRecordTypes)
 	assert.Equal(t, uint32(300), cfg.responseTTL)
+	assert.NotNil(t, cfg.conflictHandler)
 }
 
 func TestServerConfigDefaults(t *testing.T) {
@@ -424,6 +428,7 @@ type mockAnswerSender struct {
 	calls        []mockAnswerCall
 	serviceCalls []mockServiceAnswerCall
 	services     []ServiceInstance
+	localNames   []string
 }
 
 type mockAnswerCall struct {
@@ -478,6 +483,10 @@ func (m *mockAnswerSender) getServices() []ServiceInstance {
 	return m.services
 }
 
+func (m *mockAnswerSender) getLocalNames() []string {
+	return m.localNames
+}
+
 // mockAnswerWriter records raw answer bytes for testing.
 type mockAnswerWriter struct {
 	writtenAnswers [][]byte
@@ -503,14 +512,13 @@ func newQuestionHandlerTestSetupWithTypes(
 	localNames []string, localAddr net.IP, allowedTypes []dnsmessage.Type,
 ) *questionHandlerTestSetup {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	sender := &mockAnswerSender{}
+	sender := &mockAnswerSender{localNames: localNames}
 	writer := &mockAnswerWriter{}
 	ifaces := map[int]netInterface{
 		1: {Interface: net.Interface{Index: 1, Flags: net.FlagMulticast | net.FlagUp}, supportsV4: true},
 	}
 
 	handler := newQuestionHandler(
-		localNames,
 		localAddr,
 		ifaces,
 		true,
@@ -551,14 +559,13 @@ func newTestQuestion(name string, qtype dnsmessage.Type, class dnsmessage.Class)
 // newQuestionHandlerTestSetupIPv6 creates a test setup for IPv6-only handlers.
 func newQuestionHandlerTestSetupIPv6(localNames []string, localAddr net.IP) *questionHandlerTestSetup {
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-	sender := &mockAnswerSender{}
+	sender := &mockAnswerSender{localNames: localNames}
 	writer := &mockAnswerWriter{}
 	ifaces := map[int]netInterface{
 		1: {Interface: net.Interface{Index: 1, Flags: net.FlagMulticast | net.FlagUp}, supportsV4: false},
 	}
 
 	handler := newQuestionHandler(
-		localNames,
 		localAddr,
 		ifaces,
 		false, // IPv6 only

--- a/server_test.go
+++ b/server_test.go
@@ -1296,3 +1296,179 @@ func TestOnProbeRenamedNoMatch(t *testing.T) {
 	srv.onProbeRenamed("Unknown._http._tcp.local.", "Unknown (2)._http._tcp.local.", false)
 	assert.Equal(t, "My Web", srv.services[0].Instance)
 }
+
+// ---------------------------------------------------------------------------
+// Probing suppression and ANY-query defense
+// ---------------------------------------------------------------------------
+
+// mockProbeChecker reports configurable probing state per name.
+type mockProbeChecker struct {
+	probing map[string]bool
+}
+
+func (m *mockProbeChecker) isProbing(name string) bool {
+	return m.probing[strings.ToLower(name)]
+}
+
+func TestQuestionHandlerSuppressedWhileProbing(t *testing.T) {
+	setup := newQuestionHandlerTestSetup([]string{"test.local."}, net.ParseIP("192.168.1.100"))
+	setup.handler.probeChecker = &mockProbeChecker{probing: map[string]bool{"test.local.": true}}
+	msgCtx := newTestMessageContext(5353)
+	msg := newTestQuestion("test.local.", dnsmessage.TypeA, dnsmessage.ClassINET)
+
+	setup.handler.handle(msgCtx, msg)
+	assert.Empty(t, setup.sender.calls, "must not answer for a name still being probed")
+
+	// Once no longer probing, the same question is answered.
+	setup.handler.probeChecker = &mockProbeChecker{probing: map[string]bool{}}
+	setup.handler.handle(msgCtx, msg)
+	assert.Len(t, setup.sender.calls, 1, "established name must be answered")
+}
+
+func TestQuestionHandlerAnyQuestionHostname(t *testing.T) {
+	setup := newQuestionHandlerTestSetup([]string{"test.local."}, net.ParseIP("192.168.1.100"))
+	msgCtx := newTestMessageContext(5353)
+	msg := newTestQuestion("test.local.", typeANY, dnsmessage.ClassINET)
+
+	setup.handler.handle(msgCtx, msg)
+
+	// IPv4-only setup: the ANY question yields an A answer (probe defense).
+	require.Len(t, setup.sender.calls, 1)
+	assert.Equal(t, dnsmessage.TypeA, setup.sender.calls[0].question.Type)
+}
+
+func TestQuestionHandlerAnyQuestionService(t *testing.T) {
+	setup := newQuestionHandlerTestSetup([]string{"myhost.local."}, net.ParseIP("192.168.1.100"))
+	setup.sender.services = []ServiceInstance{{
+		Instance: "Web",
+		Service:  "_http._tcp",
+		Domain:   "local",
+		Host:     "myhost.local.",
+		Port:     8080,
+	}}
+	msgCtx := newTestMessageContext(5353)
+	msg := newTestQuestion("Web._http._tcp.local.", typeANY, dnsmessage.ClassINET)
+
+	setup.handler.handle(msgCtx, msg)
+
+	// The instance name matches SRV and TXT dispatch.
+	require.Len(t, setup.sender.serviceCalls, 2)
+	assert.Equal(t, dnsmessage.TypeSRV, setup.sender.serviceCalls[0].question.Type)
+	assert.Equal(t, dnsmessage.TypeTXT, setup.sender.serviceCalls[1].question.Type)
+	assert.Empty(t, setup.sender.calls, "no address answer for an instance name")
+}
+
+func TestQuestionHandlerAnyQuestionRespectsFilter(t *testing.T) {
+	setup := newQuestionHandlerTestSetupWithTypes(
+		[]string{"test.local."}, net.ParseIP("192.168.1.100"),
+		[]dnsmessage.Type{dnsmessage.TypeA, dnsmessage.TypeAAAA},
+	)
+	setup.sender.services = []ServiceInstance{{
+		Instance: "Web",
+		Service:  "_http._tcp",
+		Domain:   "local",
+		Host:     "test.local.",
+		Port:     8080,
+	}}
+	msgCtx := newTestMessageContext(5353)
+
+	// ANY for the hostname is answered with the allowed A type.
+	setup.handler.handle(msgCtx, newTestQuestion("test.local.", typeANY, dnsmessage.ClassINET))
+	require.Len(t, setup.sender.calls, 1)
+	assert.Equal(t, dnsmessage.TypeA, setup.sender.calls[0].question.Type)
+
+	// ANY for the instance name yields nothing: SRV/TXT are filtered out.
+	setup.handler.handle(msgCtx, newTestQuestion("Web._http._tcp.local.", typeANY, dnsmessage.ClassINET))
+	assert.Empty(t, setup.sender.serviceCalls, "filtered types must not be dispatched for ANY")
+}
+
+func TestQuestionHandlerAnySuppressedWhileProbing(t *testing.T) {
+	setup := newQuestionHandlerTestSetup([]string{"test.local."}, net.ParseIP("192.168.1.100"))
+	setup.handler.probeChecker = &mockProbeChecker{probing: map[string]bool{"test.local.": true}}
+	msgCtx := newTestMessageContext(5353)
+
+	// A probe (ANY) from another host for a name we are still probing
+	// ourselves must not be defended (§8.1 — tiebreaking handles it).
+	setup.handler.handle(msgCtx, newTestQuestion("test.local.", typeANY, dnsmessage.ClassINET))
+	assert.Empty(t, setup.sender.calls)
+}
+
+// ---------------------------------------------------------------------------
+// Probe session construction
+// ---------------------------------------------------------------------------
+
+func TestBuildHostProbeRecords(t *testing.T) {
+	ifaces := map[int]netInterface{
+		1: {
+			Interface: net.Interface{Index: 1},
+			ipAddrs: []netip.Addr{
+				netip.MustParseAddr("192.168.1.5"),
+				netip.MustParseAddr("fe80::1"),
+			},
+		},
+	}
+
+	// IPv4 only.
+	recs := buildHostProbeRecords("myhost.local.", ifaces, 120, true, false, nil)
+	require.Len(t, recs, 1)
+	assert.Equal(t, dnsmessage.TypeA, recs[0].Header.Type)
+
+	// IPv4 + IPv6.
+	recs = buildHostProbeRecords("myhost.local.", ifaces, 120, true, true, nil)
+	assert.Len(t, recs, 2)
+
+	// 4-in-6 mapped interface addresses are unmapped to plain IPv4.
+	mapped := map[int]netInterface{
+		1: {Interface: net.Interface{Index: 1}, ipAddrs: []netip.Addr{netip.MustParseAddr("::ffff:10.0.0.1")}},
+	}
+	recs = buildHostProbeRecords("myhost.local.", mapped, 120, true, true, nil)
+	require.Len(t, recs, 1)
+	assert.Equal(t, dnsmessage.TypeA, recs[0].Header.Type)
+
+	// Explicit local address takes precedence over interface addresses.
+	recs = buildHostProbeRecords("myhost.local.", ifaces, 120, true, true, net.ParseIP("10.1.2.3"))
+	require.Len(t, recs, 1)
+	body, ok := recs[0].Body.(*dnsmessage.AResource)
+	require.True(t, ok)
+	assert.Equal(t, [4]byte{10, 1, 2, 3}, body.A)
+}
+
+func TestBuildProbeSessionsSharedPTR(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	pm := newProbeManager(nil, nil, log, "test", nil, nil)
+
+	ifaces := map[int]netInterface{
+		1: {Interface: net.Interface{Index: 1}, ipAddrs: []netip.Addr{netip.MustParseAddr("192.168.1.5")}},
+	}
+	services := []ServiceInstance{{
+		Instance: "Web",
+		Service:  "_http._tcp",
+		Domain:   "local",
+		Host:     "myhost.local.",
+		Port:     8080,
+	}}
+
+	buildProbeSessions(pm, []string{"myhost.local."}, services, ifaces, 120, true, false, nil)
+
+	require.Len(t, pm.sessions, 2)
+
+	host := pm.sessions[0]
+	assert.True(t, host.isHost)
+	require.Len(t, host.records, 1)
+	assert.Equal(t, dnsmessage.TypeA, host.records[0].Header.Type)
+	assert.Empty(t, host.shared, "hostnames have no shared records")
+
+	svc := pm.sessions[1]
+	assert.False(t, svc.isHost)
+	require.Len(t, svc.records, 2, "SRV + TXT are the unique records")
+	assert.Equal(t, dnsmessage.TypeSRV, svc.records[0].Header.Type)
+	assert.Equal(t, dnsmessage.TypeTXT, svc.records[1].Header.Type)
+
+	require.Len(t, svc.shared, 1, "service-type PTR is shared")
+	assert.Equal(t, dnsmessage.TypePTR, svc.shared[0].Header.Type)
+	assert.Equal(t, "_http._tcp.local.", svc.shared[0].Header.Name.String())
+
+	ptrBody, ok := svc.shared[0].Body.(*dnsmessage.PTRResource)
+	require.True(t, ok)
+	assert.Equal(t, "Web._http._tcp.local.", ptrBody.PTR.String())
+}

--- a/server_test.go
+++ b/server_test.go
@@ -1186,3 +1186,113 @@ func TestCreateServiceAnswerIPv6(t *testing.T) {
 	assert.Len(t, msg.Additionals, 3)
 	assert.Equal(t, dnsmessage.TypeAAAA, msg.Additionals[2].Header.Type)
 }
+
+// ---------------------------------------------------------------------------
+// onProbeRenamed — service instance rename
+// ---------------------------------------------------------------------------
+
+func TestOnProbeRenamedHostname(t *testing.T) {
+	srv := &server{
+		localNames: []string{"myhost.local.", "other.local."},
+		services: []ServiceInstance{
+			{
+				Instance: "Web",
+				Service:  "_http._tcp",
+				Domain:   "local",
+				Host:     "myhost.local.",
+				Port:     8080,
+			},
+			{
+				Instance: "SSH",
+				Service:  "_ssh._tcp",
+				Domain:   "local",
+				Host:     "other.local.",
+				Port:     22,
+			},
+		},
+	}
+
+	srv.onProbeRenamed("myhost.local.", "myhost-2.local.", true)
+
+	// First name renamed, second untouched.
+	assert.Equal(t, "myhost-2.local.", srv.localNames[0])
+	assert.Equal(t, "other.local.", srv.localNames[1])
+
+	// Service referencing old host updated, other service untouched.
+	assert.Equal(t, "myhost-2.local.", srv.services[0].Host)
+	assert.Equal(t, "other.local.", srv.services[1].Host)
+}
+
+func TestOnProbeRenamedHostnameCaseInsensitive(t *testing.T) {
+	srv := &server{
+		localNames: []string{"MyHost.Local."},
+	}
+
+	srv.onProbeRenamed("myhost.local.", "myhost-2.local.", true)
+
+	assert.Equal(t, "myhost-2.local.", srv.localNames[0])
+}
+
+func TestOnProbeRenamedServiceInstance(t *testing.T) {
+	srv := &server{
+		localNames: []string{"myhost.local."},
+		services: []ServiceInstance{{
+			Instance: "My Web",
+			Service:  "_http._tcp",
+			Domain:   "local",
+			Host:     "myhost.local.",
+			Port:     8080,
+		}},
+	}
+
+	srv.onProbeRenamed(
+		"My Web._http._tcp.local.",
+		"My Web (2)._http._tcp.local.",
+		false,
+	)
+
+	assert.Equal(t, "My Web (2)", srv.services[0].Instance)
+	// Host and localNames unchanged.
+	assert.Equal(t, "myhost.local.", srv.services[0].Host)
+	assert.Equal(t, []string{"myhost.local."}, srv.localNames)
+}
+
+func TestOnProbeRenamedServiceInstanceWithDots(t *testing.T) {
+	srv := &server{
+		services: []ServiceInstance{{
+			Instance: "My.Web",
+			Service:  "_http._tcp",
+			Domain:   "local",
+			Host:     "myhost.local.",
+			Port:     8080,
+		}},
+	}
+
+	srv.onProbeRenamed(
+		"My\\.Web._http._tcp.local.",
+		"My\\.Web (2)._http._tcp.local.",
+		false,
+	)
+
+	assert.Equal(t, "My.Web (2)", srv.services[0].Instance)
+}
+
+func TestOnProbeRenamedNoMatch(t *testing.T) {
+	srv := &server{
+		localNames: []string{"myhost.local."},
+		services: []ServiceInstance{{
+			Instance: "My Web",
+			Service:  "_http._tcp",
+			Domain:   "local",
+			Host:     "myhost.local.",
+			Port:     8080,
+		}},
+	}
+
+	// Rename for an unknown name is a no-op.
+	srv.onProbeRenamed("unknown.local.", "unknown-2.local.", true)
+	assert.Equal(t, "myhost.local.", srv.localNames[0])
+
+	srv.onProbeRenamed("Unknown._http._tcp.local.", "Unknown (2)._http._tcp.local.", false)
+	assert.Equal(t, "My Web", srv.services[0].Instance)
+}

--- a/server_test.go
+++ b/server_test.go
@@ -1067,7 +1067,7 @@ func TestServerUpdateTXT(t *testing.T) {
 	assert.Zero(t, unchangedGeneration)
 	assert.Len(t, writer.writtenAnswers, 1)
 
-	require.NoError(t, srv.repeatTXTAnnouncement("Test", "_http._tcp", generation))
+	require.NoError(t, srv.repeatTXTAnnouncement(generation))
 	assert.Len(t, writer.writtenAnswers, 2)
 }
 
@@ -1091,8 +1091,8 @@ func TestServerUpdateTXTSupersedesRepeatedAnnouncement(t *testing.T) {
 	require.NoError(t, err)
 	second, err := srv.updateTXT("Test", "_http._tcp", []TXTEntry{NewTXTString("version", "2")})
 	require.NoError(t, err)
-	require.NoError(t, srv.repeatTXTAnnouncement("Test", "_http._tcp", first))
-	require.NoError(t, srv.repeatTXTAnnouncement("Test", "_http._tcp", second))
+	require.NoError(t, srv.repeatTXTAnnouncement(first))
+	require.NoError(t, srv.repeatTXTAnnouncement(second))
 
 	assert.Len(t, writer.writtenAnswers, 3)
 }
@@ -1116,7 +1116,7 @@ func TestServerUnregisterCancelsTXTRepeat(t *testing.T) {
 		Text:     []TXTEntry{NewTXTString("version", "2")},
 	})
 
-	require.NoError(t, srv.repeatTXTAnnouncement("Test", "_http._tcp", generation))
+	require.NoError(t, srv.repeatTXTAnnouncement(generation))
 	assert.Len(t, writer.writtenAnswers, 1)
 }
 
@@ -1560,4 +1560,146 @@ func TestBuildProbeSessionsSharedPTR(t *testing.T) {
 	ptrBody, ok := svc.shared[0].Body.(*dnsmessage.PTRResource)
 	require.True(t, ok)
 	assert.Equal(t, "Web._http._tcp.local.", ptrBody.PTR.String())
+}
+
+// ---------------------------------------------------------------------------
+// TXT updates (#291) combined with probe renames (#271)
+// ---------------------------------------------------------------------------
+
+// newTXTRenameTestServer builds a server whose single service is subject to
+// probing, so probe renames and TXT updates can be exercised together.
+func newTXTRenameTestServer() (*server, *mockAnswerWriter) {
+	writer := &mockAnswerWriter{}
+	srv := &server{ttl: 120, writer: writer}
+	srv.registerService(ServiceInstance{
+		Instance: "My Web",
+		Service:  "_http._tcp",
+		Domain:   "local",
+		Host:     "myhost.local.",
+		Port:     8080,
+	})
+
+	return srv, writer
+}
+
+// A probe rename must not orphan a pending TXT announcement: the repeat is
+// located by generation, so it still fires for the renamed instance.
+func TestServerRepeatTXTAnnouncementSurvivesProbeRename(t *testing.T) {
+	srv, writer := newTXTRenameTestServer()
+
+	generation, err := srv.updateTXT("My Web", "_http._tcp", []TXTEntry{NewTXTString("version", "2")})
+	require.NoError(t, err)
+	require.NotZero(t, generation)
+	require.Len(t, writer.writtenAnswers, 1)
+
+	srv.onProbeRenamed("My Web._http._tcp.local.", "My Web (2)._http._tcp.local.", false)
+	require.Equal(t, "My Web (2)", srv.services[0].Instance)
+
+	require.NoError(t, srv.repeatTXTAnnouncement(generation))
+	assert.Len(t, writer.writtenAnswers, 2, "repeat announcement must still be sent after a rename")
+
+	// The generation entry follows the rename rather than leaking under the
+	// old name, so unregistering by the current name clears it.
+	srv.unregisterService("My Web (2)", "_http._tcp")
+	assert.Empty(t, srv.txtAnnouncementGenerations)
+}
+
+// The repeat announcement carries the TXT data recorded by updateTXT, and
+// names the service by its post-rename instance name.
+func TestServerRepeatTXTAnnouncementUsesRenamedName(t *testing.T) {
+	srv, writer := newTXTRenameTestServer()
+
+	generation, err := srv.updateTXT("My Web", "_http._tcp", []TXTEntry{NewTXTString("version", "2")})
+	require.NoError(t, err)
+
+	srv.onProbeRenamed("My Web._http._tcp.local.", "My Web (2)._http._tcp.local.", false)
+	require.NoError(t, srv.repeatTXTAnnouncement(generation))
+	require.Len(t, writer.writtenAnswers, 2)
+
+	var msg dnsmessage.Message
+	require.NoError(t, msg.Unpack(writer.writtenAnswers[1]))
+	require.Len(t, msg.Answers, 1)
+	assert.Equal(t, "My Web (2)._http._tcp.local.", msg.Answers[0].Header.Name.String())
+}
+
+// A rename of an unrelated service must not move another service's pending
+// generation.
+func TestServerRekeyTXTGenerationIgnoresOtherServices(t *testing.T) {
+	srv, _ := newTXTRenameTestServer()
+	srv.registerService(ServiceInstance{
+		Instance: "Other",
+		Service:  "_ipp._tcp",
+		Domain:   "local",
+	})
+
+	generation, err := srv.updateTXT("My Web", "_http._tcp", []TXTEntry{NewTXTString("version", "2")})
+	require.NoError(t, err)
+
+	srv.onProbeRenamed("Other._ipp._tcp.local.", "Other (2)._ipp._tcp.local.", false)
+
+	key, ok := srv.keyForGenerationLocked(generation)
+	require.True(t, ok)
+	assert.Equal(t, registeredServiceKey{instance: "My Web", service: "_http._tcp"}, key)
+}
+
+// A hostname rename leaves service instance names, and therefore pending TXT
+// generations, untouched.
+func TestServerHostRenameKeepsTXTGeneration(t *testing.T) {
+	srv, writer := newTXTRenameTestServer()
+
+	generation, err := srv.updateTXT("My Web", "_http._tcp", []TXTEntry{NewTXTString("version", "2")})
+	require.NoError(t, err)
+
+	srv.onProbeRenamed("myhost.local.", "myhost-2.local.", true)
+	require.Equal(t, "myhost-2.local.", srv.services[0].Host)
+
+	require.NoError(t, srv.repeatTXTAnnouncement(generation))
+	assert.Len(t, writer.writtenAnswers, 2)
+}
+
+// nopQuestionWriter discards probe questions.
+type nopQuestionWriter struct{}
+
+func (nopQuestionWriter) writeQuestion([]byte) {}
+
+// A TXT update for a name that is still being probed must record the new data
+// but must not announce it: the name has not been claimed yet (RFC 6762 §8.2).
+// The announcement that follows a successful probe carries the new TXT data.
+func TestServerUpdateTXTSuppressedWhileProbing(t *testing.T) {
+	srv, writer := newTXTRenameTestServer()
+
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	srv.probes = newProbeManager(nopQuestionWriter{}, writer, log, "test", nil, nil)
+	srv.probes.addSession("My Web._http._tcp.local.", nil, false)
+	require.True(t, srv.probes.isProbing("My Web._http._tcp.local."))
+
+	generation, err := srv.updateTXT("My Web", "_http._tcp", []TXTEntry{NewTXTString("version", "2")})
+	require.NoError(t, err)
+	require.NotZero(t, generation)
+
+	assert.Empty(t, writer.writtenAnswers, "must not announce a name that is still being probed")
+	assert.Equal(t, []TXTEntry{NewTXTString("version", "2")}, srv.services[0].Text,
+		"the update is still recorded so the post-probe announcement carries it")
+
+	// The repeat is suppressed for the same reason.
+	require.NoError(t, srv.repeatTXTAnnouncement(generation))
+	assert.Empty(t, writer.writtenAnswers)
+}
+
+// Once probing has established the name, TXT updates announce normally.
+func TestServerUpdateTXTAnnouncesAfterProbeEstablished(t *testing.T) {
+	srv, writer := newTXTRenameTestServer()
+
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	srv.probes = newProbeManager(nopQuestionWriter{}, writer, log, "test", nil, nil)
+	srv.probes.addSession("My Web._http._tcp.local.", nil, false)
+	srv.probes.sessions[0].state = probeStateEstablished
+	require.False(t, srv.probes.isProbing("My Web._http._tcp.local."))
+
+	generation, err := srv.updateTXT("My Web", "_http._tcp", []TXTEntry{NewTXTString("version", "2")})
+	require.NoError(t, err)
+
+	require.Len(t, writer.writtenAnswers, 1)
+	require.NoError(t, srv.repeatTXTAnnouncement(generation))
+	assert.Len(t, writer.writtenAnswers, 2)
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1275,3 +1275,113 @@ func TestCreateServiceAnswerIPv6(t *testing.T) {
 	assert.Len(t, msg.Additionals, 3)
 	assert.Equal(t, dnsmessage.TypeAAAA, msg.Additionals[2].Header.Type)
 }
+
+// ---------------------------------------------------------------------------
+// onProbeRenamed — service instance rename
+// ---------------------------------------------------------------------------
+
+func TestOnProbeRenamedHostname(t *testing.T) {
+	srv := &server{
+		localNames: []string{"myhost.local.", "other.local."},
+		services: []ServiceInstance{
+			{
+				Instance: "Web",
+				Service:  "_http._tcp",
+				Domain:   "local",
+				Host:     "myhost.local.",
+				Port:     8080,
+			},
+			{
+				Instance: "SSH",
+				Service:  "_ssh._tcp",
+				Domain:   "local",
+				Host:     "other.local.",
+				Port:     22,
+			},
+		},
+	}
+
+	srv.onProbeRenamed("myhost.local.", "myhost-2.local.", true)
+
+	// First name renamed, second untouched.
+	assert.Equal(t, "myhost-2.local.", srv.localNames[0])
+	assert.Equal(t, "other.local.", srv.localNames[1])
+
+	// Service referencing old host updated, other service untouched.
+	assert.Equal(t, "myhost-2.local.", srv.services[0].Host)
+	assert.Equal(t, "other.local.", srv.services[1].Host)
+}
+
+func TestOnProbeRenamedHostnameCaseInsensitive(t *testing.T) {
+	srv := &server{
+		localNames: []string{"MyHost.Local."},
+	}
+
+	srv.onProbeRenamed("myhost.local.", "myhost-2.local.", true)
+
+	assert.Equal(t, "myhost-2.local.", srv.localNames[0])
+}
+
+func TestOnProbeRenamedServiceInstance(t *testing.T) {
+	srv := &server{
+		localNames: []string{"myhost.local."},
+		services: []ServiceInstance{{
+			Instance: "My Web",
+			Service:  "_http._tcp",
+			Domain:   "local",
+			Host:     "myhost.local.",
+			Port:     8080,
+		}},
+	}
+
+	srv.onProbeRenamed(
+		"My Web._http._tcp.local.",
+		"My Web (2)._http._tcp.local.",
+		false,
+	)
+
+	assert.Equal(t, "My Web (2)", srv.services[0].Instance)
+	// Host and localNames unchanged.
+	assert.Equal(t, "myhost.local.", srv.services[0].Host)
+	assert.Equal(t, []string{"myhost.local."}, srv.localNames)
+}
+
+func TestOnProbeRenamedServiceInstanceWithDots(t *testing.T) {
+	srv := &server{
+		services: []ServiceInstance{{
+			Instance: "My.Web",
+			Service:  "_http._tcp",
+			Domain:   "local",
+			Host:     "myhost.local.",
+			Port:     8080,
+		}},
+	}
+
+	srv.onProbeRenamed(
+		"My\\.Web._http._tcp.local.",
+		"My\\.Web (2)._http._tcp.local.",
+		false,
+	)
+
+	assert.Equal(t, "My.Web (2)", srv.services[0].Instance)
+}
+
+func TestOnProbeRenamedNoMatch(t *testing.T) {
+	srv := &server{
+		localNames: []string{"myhost.local."},
+		services: []ServiceInstance{{
+			Instance: "My Web",
+			Service:  "_http._tcp",
+			Domain:   "local",
+			Host:     "myhost.local.",
+			Port:     8080,
+		}},
+	}
+
+	// Rename for an unknown name is a no-op.
+	srv.onProbeRenamed("unknown.local.", "unknown-2.local.", true)
+	assert.Equal(t, "myhost.local.", srv.localNames[0])
+
+	srv.onProbeRenamed("Unknown._http._tcp.local.", "Unknown (2)._http._tcp.local.", false)
+	assert.Equal(t, "My Web", srv.services[0].Instance)
+}

--- a/server_test.go
+++ b/server_test.go
@@ -1385,3 +1385,179 @@ func TestOnProbeRenamedNoMatch(t *testing.T) {
 	srv.onProbeRenamed("Unknown._http._tcp.local.", "Unknown (2)._http._tcp.local.", false)
 	assert.Equal(t, "My Web", srv.services[0].Instance)
 }
+
+// ---------------------------------------------------------------------------
+// Probing suppression and ANY-query defense
+// ---------------------------------------------------------------------------
+
+// mockProbeChecker reports configurable probing state per name.
+type mockProbeChecker struct {
+	probing map[string]bool
+}
+
+func (m *mockProbeChecker) isProbing(name string) bool {
+	return m.probing[strings.ToLower(name)]
+}
+
+func TestQuestionHandlerSuppressedWhileProbing(t *testing.T) {
+	setup := newQuestionHandlerTestSetup([]string{"test.local."}, net.ParseIP("192.168.1.100"))
+	setup.handler.probeChecker = &mockProbeChecker{probing: map[string]bool{"test.local.": true}}
+	msgCtx := newTestMessageContext(5353)
+	msg := newTestQuestion("test.local.", dnsmessage.TypeA, dnsmessage.ClassINET)
+
+	setup.handler.handle(msgCtx, msg)
+	assert.Empty(t, setup.sender.calls, "must not answer for a name still being probed")
+
+	// Once no longer probing, the same question is answered.
+	setup.handler.probeChecker = &mockProbeChecker{probing: map[string]bool{}}
+	setup.handler.handle(msgCtx, msg)
+	assert.Len(t, setup.sender.calls, 1, "established name must be answered")
+}
+
+func TestQuestionHandlerAnyQuestionHostname(t *testing.T) {
+	setup := newQuestionHandlerTestSetup([]string{"test.local."}, net.ParseIP("192.168.1.100"))
+	msgCtx := newTestMessageContext(5353)
+	msg := newTestQuestion("test.local.", typeANY, dnsmessage.ClassINET)
+
+	setup.handler.handle(msgCtx, msg)
+
+	// IPv4-only setup: the ANY question yields an A answer (probe defense).
+	require.Len(t, setup.sender.calls, 1)
+	assert.Equal(t, dnsmessage.TypeA, setup.sender.calls[0].question.Type)
+}
+
+func TestQuestionHandlerAnyQuestionService(t *testing.T) {
+	setup := newQuestionHandlerTestSetup([]string{"myhost.local."}, net.ParseIP("192.168.1.100"))
+	setup.sender.services = []ServiceInstance{{
+		Instance: "Web",
+		Service:  "_http._tcp",
+		Domain:   "local",
+		Host:     "myhost.local.",
+		Port:     8080,
+	}}
+	msgCtx := newTestMessageContext(5353)
+	msg := newTestQuestion("Web._http._tcp.local.", typeANY, dnsmessage.ClassINET)
+
+	setup.handler.handle(msgCtx, msg)
+
+	// The instance name matches SRV and TXT dispatch.
+	require.Len(t, setup.sender.serviceCalls, 2)
+	assert.Equal(t, dnsmessage.TypeSRV, setup.sender.serviceCalls[0].question.Type)
+	assert.Equal(t, dnsmessage.TypeTXT, setup.sender.serviceCalls[1].question.Type)
+	assert.Empty(t, setup.sender.calls, "no address answer for an instance name")
+}
+
+func TestQuestionHandlerAnyQuestionRespectsFilter(t *testing.T) {
+	setup := newQuestionHandlerTestSetupWithTypes(
+		[]string{"test.local."}, net.ParseIP("192.168.1.100"),
+		[]dnsmessage.Type{dnsmessage.TypeA, dnsmessage.TypeAAAA},
+	)
+	setup.sender.services = []ServiceInstance{{
+		Instance: "Web",
+		Service:  "_http._tcp",
+		Domain:   "local",
+		Host:     "test.local.",
+		Port:     8080,
+	}}
+	msgCtx := newTestMessageContext(5353)
+
+	// ANY for the hostname is answered with the allowed A type.
+	setup.handler.handle(msgCtx, newTestQuestion("test.local.", typeANY, dnsmessage.ClassINET))
+	require.Len(t, setup.sender.calls, 1)
+	assert.Equal(t, dnsmessage.TypeA, setup.sender.calls[0].question.Type)
+
+	// ANY for the instance name yields nothing: SRV/TXT are filtered out.
+	setup.handler.handle(msgCtx, newTestQuestion("Web._http._tcp.local.", typeANY, dnsmessage.ClassINET))
+	assert.Empty(t, setup.sender.serviceCalls, "filtered types must not be dispatched for ANY")
+}
+
+func TestQuestionHandlerAnySuppressedWhileProbing(t *testing.T) {
+	setup := newQuestionHandlerTestSetup([]string{"test.local."}, net.ParseIP("192.168.1.100"))
+	setup.handler.probeChecker = &mockProbeChecker{probing: map[string]bool{"test.local.": true}}
+	msgCtx := newTestMessageContext(5353)
+
+	// A probe (ANY) from another host for a name we are still probing
+	// ourselves must not be defended (§8.1 — tiebreaking handles it).
+	setup.handler.handle(msgCtx, newTestQuestion("test.local.", typeANY, dnsmessage.ClassINET))
+	assert.Empty(t, setup.sender.calls)
+}
+
+// ---------------------------------------------------------------------------
+// Probe session construction
+// ---------------------------------------------------------------------------
+
+func TestBuildHostProbeRecords(t *testing.T) {
+	ifaces := map[int]netInterface{
+		1: {
+			Interface: net.Interface{Index: 1},
+			ipAddrs: []netip.Addr{
+				netip.MustParseAddr("192.168.1.5"),
+				netip.MustParseAddr("fe80::1"),
+			},
+		},
+	}
+
+	// IPv4 only.
+	recs := buildHostProbeRecords("myhost.local.", ifaces, 120, true, false, nil)
+	require.Len(t, recs, 1)
+	assert.Equal(t, dnsmessage.TypeA, recs[0].Header.Type)
+
+	// IPv4 + IPv6.
+	recs = buildHostProbeRecords("myhost.local.", ifaces, 120, true, true, nil)
+	assert.Len(t, recs, 2)
+
+	// 4-in-6 mapped interface addresses are unmapped to plain IPv4.
+	mapped := map[int]netInterface{
+		1: {Interface: net.Interface{Index: 1}, ipAddrs: []netip.Addr{netip.MustParseAddr("::ffff:10.0.0.1")}},
+	}
+	recs = buildHostProbeRecords("myhost.local.", mapped, 120, true, true, nil)
+	require.Len(t, recs, 1)
+	assert.Equal(t, dnsmessage.TypeA, recs[0].Header.Type)
+
+	// Explicit local address takes precedence over interface addresses.
+	recs = buildHostProbeRecords("myhost.local.", ifaces, 120, true, true, net.ParseIP("10.1.2.3"))
+	require.Len(t, recs, 1)
+	body, ok := recs[0].Body.(*dnsmessage.AResource)
+	require.True(t, ok)
+	assert.Equal(t, [4]byte{10, 1, 2, 3}, body.A)
+}
+
+func TestBuildProbeSessionsSharedPTR(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	pm := newProbeManager(nil, nil, log, "test", nil, nil)
+
+	ifaces := map[int]netInterface{
+		1: {Interface: net.Interface{Index: 1}, ipAddrs: []netip.Addr{netip.MustParseAddr("192.168.1.5")}},
+	}
+	services := []ServiceInstance{{
+		Instance: "Web",
+		Service:  "_http._tcp",
+		Domain:   "local",
+		Host:     "myhost.local.",
+		Port:     8080,
+	}}
+
+	buildProbeSessions(pm, []string{"myhost.local."}, services, ifaces, 120, true, false, nil)
+
+	require.Len(t, pm.sessions, 2)
+
+	host := pm.sessions[0]
+	assert.True(t, host.isHost)
+	require.Len(t, host.records, 1)
+	assert.Equal(t, dnsmessage.TypeA, host.records[0].Header.Type)
+	assert.Empty(t, host.shared, "hostnames have no shared records")
+
+	svc := pm.sessions[1]
+	assert.False(t, svc.isHost)
+	require.Len(t, svc.records, 2, "SRV + TXT are the unique records")
+	assert.Equal(t, dnsmessage.TypeSRV, svc.records[0].Header.Type)
+	assert.Equal(t, dnsmessage.TypeTXT, svc.records[1].Header.Type)
+
+	require.Len(t, svc.shared, 1, "service-type PTR is shared")
+	assert.Equal(t, dnsmessage.TypePTR, svc.shared[0].Header.Type)
+	assert.Equal(t, "_http._tcp.local.", svc.shared[0].Header.Name.String())
+
+	ptrBody, ok := svc.shared[0].Body.(*dnsmessage.PTRResource)
+	require.True(t, ok)
+	assert.Equal(t, "Web._http._tcp.local.", ptrBody.PTR.String())
+}


### PR DESCRIPTION
## Summary

- `probe.go`: State machine for name probing (delay→probing→announcing→established), simultaneous probe tiebreaking (§8.2), conflict detection across all RR sections (§9), rename + re-probe with rate limiting
- `config.go`: `WithProbing()`, `WithConflictHandler()` options
- `conn.go`: `WaitReady()`, atomic.Value conflict handler (unexported setter, ready to expose as `OnConflict` later)
- `server.go`: `probeManager` integration, `buildProbeSessions`, `onProbeRenamed` callback
- 37 unit tests in `probe_test.go`, deterministic via fake timers + `sync.Cond`

Opening as draft for early review feedback.

## Open questions

1. `probe.go` is ~950 lines. Should we split it further, e.g.:
   - `probe.go` — state machine + manager
   - `probe_tiebreak.go` — `lexicographicCompare`, `sortResources`, `compareResource`, `packRData`
   - `probe_rename.go` — `defaultRename`, `defaultRenameHost`, `defaultRenameServiceInstance`
   
   Or is one file fine given the tight coupling?

2. `WaitReady(ctx) error` is currently exported on `Conn`. Is this the right API surface, or should readiness be signaled differently (e.g. callback, channel field)?