### PR TITLE
Export TXTEntry so callers can set TXT records on advertised services

### DIFF
--- a/client.go
+++ b/client.go
@@ -360,7 +360,7 @@ type pendingInstance struct {
 	port     uint16
 	priority uint16
 	weight   uint16
-	text     []txtKeyValue
+	text     []TXTEntry
 	addr     netip.Addr
 	hasSRV   bool
 	hasTXT   bool

--- a/config.go
+++ b/config.go
@@ -242,6 +242,10 @@ func (o serviceOption) applyServer(cfg *serverConfig) error {
 		return err
 	}
 
+	if err := validateTXTEntries(o.svc.Text); err != nil {
+		return err
+	}
+
 	// Default domain to "local".
 	if o.svc.Domain == "" {
 		o.svc.Domain = "local"

--- a/conn_test.go
+++ b/conn_test.go
@@ -1039,7 +1039,7 @@ func TestBrowseEndToEnd(t *testing.T) {
 				Instance: "My Web Server",
 				Service:  "_http._tcp",
 				Port:     8080,
-				Text:     []txtKeyValue{{Key: "path", Value: []byte("/")}},
+				Text:     []TXTEntry{NewTXTEntry("path", "/")},
 			}),
 		}, darwinOpts...)...,
 	)

--- a/conn_test.go
+++ b/conn_test.go
@@ -1039,7 +1039,7 @@ func TestBrowseEndToEnd(t *testing.T) {
 				Instance: "My Web Server",
 				Service:  "_http._tcp",
 				Port:     8080,
-				Text:     []TXTEntry{NewTXTEntry("path", "/")},
+				Text:     []TXTEntry{NewTXTString("path", "/")},
 			}),
 		}, darwinOpts...)...,
 	)

--- a/dns_sd.go
+++ b/dns_sd.go
@@ -77,7 +77,7 @@ type ServiceInstance struct {
 	Weight uint16
 
 	// Text contains the key/value pairs for the TXT record.
-	Text []txtKeyValue
+	Text []TXTEntry
 }
 
 // serviceInstanceName returns the fully-qualified DNS name for this instance.

--- a/e2e/cgi-bin/browse
+++ b/e2e/cgi-bin/browse
@@ -4,6 +4,9 @@
 
 # CGI script that runs avahi-browse for a service type passed via query string.
 # Example: /cgi-bin/browse?_pion-test._tcp
+#
+# -r resolves each instance so SRV/TXT data (e.g. the TXT key=value pairs) is
+# included in the parsable "=" lines, letting callers assert on advertised TXT.
 
 printf "Content-Type: text/plain\r\n\r\n"
 SERVICE_TYPE="${QUERY_STRING}"
@@ -11,4 +14,4 @@ if [ -z "$SERVICE_TYPE" ]; then
   echo "ERROR: pass service type as query string"
   exit 0
 fi
-avahi-browse -t -p --no-db-lookup "$SERVICE_TYPE" 2>&1
+avahi-browse -t -r -p --no-db-lookup "$SERVICE_TYPE" 2>&1

--- a/e2e/main.go
+++ b/e2e/main.go
@@ -203,7 +203,7 @@ func testReverse() error {
 			Service:  "_pion-test._tcp",
 			Port:     9999,
 			Text: []mdns.TXTEntry{
-				mdns.NewTXTEntry("version", "1.2.3"),
+				mdns.NewTXTString("version", "1.2.3"),
 				mdns.NewTXTFlag("secure"),
 			},
 		}),
@@ -222,7 +222,13 @@ func testReverse() error {
 
 	for {
 		out, err := avahiBrowseHTTP(ctx, "_pion-test._tcp")
-		if err == nil && strings.Contains(out, "+;") && strings.Contains(out, "_pion-test._tcp") {
+		// "=;" is the parsable resolved line emitted by `avahi-browse -r`; it
+		// carries the TXT data, so we additionally assert our advertised entry
+		// (version=1.2.3) is visible to confirm TXT records propagate.
+		if err == nil &&
+			strings.Contains(out, "_pion-test._tcp") &&
+			strings.Contains(out, "=;") &&
+			strings.Contains(out, "version=1.2.3") {
 			fmt.Printf("    avahi-browse saw: %s\n", strings.TrimSpace(out))
 
 			return nil
@@ -230,7 +236,7 @@ func testReverse() error {
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("timed out waiting for avahi-browse to see _pion-test._tcp (last output: %q, last err: %v)", out, err)
+			return fmt.Errorf("timed out waiting for avahi-browse to see _pion-test._tcp with TXT (last output: %q, last err: %v)", out, err)
 		case <-ticker.C:
 		}
 	}

--- a/e2e/main.go
+++ b/e2e/main.go
@@ -202,6 +202,10 @@ func testReverse() error {
 			Instance: "Pion E2E Test",
 			Service:  "_pion-test._tcp",
 			Port:     9999,
+			Text: []mdns.TXTEntry{
+				mdns.NewTXTEntry("version", "1.2.3"),
+				mdns.NewTXTFlag("secure"),
+			},
 		}),
 	)
 	if err != nil {

--- a/records.go
+++ b/records.go
@@ -27,16 +27,31 @@ var (
 	errNotTXTResource   = errors.New("mDNS: resource body is not TXT")
 )
 
-// txtKeyValue represents a single key=value pair in a DNS-SD TXT record
+// TXTEntry represents a single key=value pair in a DNS-SD TXT record
 // (RFC 6763 §6). Key is case-insensitive, printable US-ASCII (0x20-0x7E)
 // excluding '=' (0x3D). Value is opaque bytes (often UTF-8).
 //
 // A nil Value indicates a boolean attribute — the key is simply present
 // with no value. An empty (non-nil, zero-length) Value represents a key
 // with an explicitly empty value (e.g. "PlugIns=").
-type txtKeyValue struct {
+//
+// Prefer the NewTXTEntry and NewTXTFlag constructors to avoid the
+// nil-vs-empty Value distinction.
+type TXTEntry struct {
 	Key   string
 	Value []byte // nil = boolean attribute (present, no value)
+}
+
+// NewTXTEntry creates a TXT entry with a key and string value, encoded on
+// the wire as "key=value". An empty value yields "key=" (RFC 6763 §6.4).
+func NewTXTEntry(key, value string) TXTEntry {
+	return TXTEntry{Key: key, Value: []byte(value)}
+}
+
+// NewTXTFlag creates a boolean TXT attribute: a key that is present with no
+// value, encoded on the wire as just "key" (RFC 6763 §6.4).
+func NewTXTFlag(key string) TXTEntry {
+	return TXTEntry{Key: key, Value: nil}
 }
 
 // encodeTXTRecordStrings converts key/value pairs into the wire-format
@@ -46,7 +61,7 @@ type txtKeyValue struct {
 //
 // An empty input slice returns a single empty string, which represents
 // the minimum valid TXT record (RFC 6763 §6.1).
-func encodeTXTRecordStrings(pairs []txtKeyValue) ([]string, error) {
+func encodeTXTRecordStrings(pairs []TXTEntry) ([]string, error) {
 	if len(pairs) == 0 {
 		return []string{""}, nil
 	}
@@ -80,8 +95,8 @@ func encodeTXTRecordStrings(pairs []txtKeyValue) ([]string, error) {
 // occurrence is kept (RFC 6763 §6.4). Strings where the key is empty
 // (i.e. starting with '=') are silently ignored (RFC 6763 §6.4).
 // Empty strings are skipped.
-func decodeTXTRecordStrings(ss []string) []txtKeyValue {
-	var out []txtKeyValue
+func decodeTXTRecordStrings(ss []string) []TXTEntry {
+	var out []TXTEntry
 	seen := make(map[string]struct{})
 
 	for _, s := range ss {
@@ -89,7 +104,7 @@ func decodeTXTRecordStrings(ss []string) []txtKeyValue {
 			continue
 		}
 
-		var kv txtKeyValue
+		var kv TXTEntry
 		if before, after, ok := strings.Cut(s, "="); ok {
 			kv.Key = before
 			kv.Value = []byte(after)

--- a/records.go
+++ b/records.go
@@ -22,6 +22,9 @@ const maxTXTStringLen = 255
 var (
 	errTXTStringTooLong = errors.New("mDNS: TXT record string exceeds 255 bytes")
 	errTXTKeyEmpty      = errors.New("mDNS: TXT record key must not be empty")
+	errTXTKeyHasEquals  = errors.New("mDNS: TXT record key must not contain '='")
+	errTXTKeyNotASCII   = errors.New("mDNS: TXT record key must be printable US-ASCII (0x20-0x7E)")
+	errTXTDuplicateKey  = errors.New("mDNS: TXT record keys must be unique (case-insensitive)")
 	errNotPTRResource   = errors.New("mDNS: resource body is not PTR")
 	errNotSRVResource   = errors.New("mDNS: resource body is not SRV")
 	errNotTXTResource   = errors.New("mDNS: resource body is not TXT")
@@ -35,23 +38,90 @@ var (
 // with no value. An empty (non-nil, zero-length) Value represents a key
 // with an explicitly empty value (e.g. "PlugIns=").
 //
-// Prefer the NewTXTEntry and NewTXTFlag constructors to avoid the
-// nil-vs-empty Value distinction.
+// Prefer the NewTXTString, NewTXTBinary, and NewTXTFlag constructors over a
+// struct literal: they map the three RFC 6763 §6.4 cases to distinct calls
+// and avoid the nil-vs-empty Value footgun.
 type TXTEntry struct {
 	Key   string
 	Value []byte // nil = boolean attribute (present, no value)
 }
 
-// NewTXTEntry creates a TXT entry with a key and string value, encoded on
+// NewTXTString creates a TXT entry with a key and string value, encoded on
 // the wire as "key=value". An empty value yields "key=" (RFC 6763 §6.4).
-func NewTXTEntry(key, value string) TXTEntry {
+func NewTXTString(key, value string) TXTEntry {
 	return TXTEntry{Key: key, Value: []byte(value)}
+}
+
+// NewTXTBinary creates a TXT entry with a key and an opaque binary value
+// (RFC 6763 §6.5), encoded on the wire as "key=<bytes>". A nil value is
+// treated as an explicit empty value ("key="); use NewTXTFlag for a boolean
+// attribute that carries no value at all.
+func NewTXTBinary(key string, value []byte) TXTEntry {
+	if value == nil {
+		value = []byte{}
+	}
+
+	return TXTEntry{Key: key, Value: value}
 }
 
 // NewTXTFlag creates a boolean TXT attribute: a key that is present with no
 // value, encoded on the wire as just "key" (RFC 6763 §6.4).
 func NewTXTFlag(key string) TXTEntry {
 	return TXTEntry{Key: key, Value: nil}
+}
+
+// validateTXTEntries checks a slice of TXT entries against the DNS-SD rules
+// (RFC 6763 §6.4, §6.7):
+//   - each key must be non-empty, contain no '=', and be printable US-ASCII;
+//   - each encoded "key=value" (or bare "key") string must not exceed 255 bytes;
+//   - keys must be unique, compared case-insensitively.
+//
+// It returns the first violation encountered, or nil if all entries are valid.
+func validateTXTEntries(entries []TXTEntry) error {
+	seen := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		if err := validateTXTKey(entry.Key); err != nil {
+			return err
+		}
+
+		// Encoded length: "key=value" (with '=') or "key" (boolean attribute).
+		encodedLen := len(entry.Key)
+		if entry.Value != nil {
+			encodedLen += 1 + len(entry.Value) // '=' separator + value bytes
+		}
+		if encodedLen > maxTXTStringLen {
+			return errTXTStringTooLong
+		}
+
+		lower := strings.ToLower(entry.Key)
+		if _, dup := seen[lower]; dup {
+			return errTXTDuplicateKey
+		}
+		seen[lower] = struct{}{}
+	}
+
+	return nil
+}
+
+// validateTXTKey checks a single TXT key against RFC 6763 §6.4: it must be
+// non-empty, must not contain '=' (0x3D), and must consist solely of
+// printable US-ASCII characters (0x20-0x7E).
+func validateTXTKey(key string) error {
+	if key == "" {
+		return errTXTKeyEmpty
+	}
+
+	for i := 0; i < len(key); i++ {
+		c := key[i]
+		switch {
+		case c == '=':
+			return errTXTKeyHasEquals
+		case c < 0x20 || c > 0x7E:
+			return errTXTKeyNotASCII
+		}
+	}
+
+	return nil
 }
 
 // encodeTXTRecordStrings converts key/value pairs into the wire-format

--- a/records_test.go
+++ b/records_test.go
@@ -20,7 +20,7 @@ import (
 func TestEncodeTXTRecordStrings_RFC6763_Section6_6(t *testing.T) {
 	// Test vector from RFC 6763 §6.6:
 	//   | 0x09 | key=value | 0x08 | paper=A4 | 0x07 | passreq |
-	pairs := []txtKeyValue{
+	pairs := []TXTEntry{
 		{Key: "key", Value: []byte("value")},
 		{Key: "paper", Value: []byte("A4")},
 		{Key: "passreq", Value: nil}, // boolean attribute
@@ -46,7 +46,7 @@ func TestEncodeTXTRecordStrings_RFC6763_Section6_6(t *testing.T) {
 
 func TestEncodeTXTRecordStrings_EmptyValue(t *testing.T) {
 	// "PlugIns=" → key present, empty value (RFC 6763 §6.4)
-	pairs := []txtKeyValue{
+	pairs := []TXTEntry{
 		{Key: "PlugIns", Value: []byte("")},
 	}
 	strs, err := encodeTXTRecordStrings(pairs)
@@ -62,7 +62,7 @@ func TestEncodeTXTRecordStrings_EmptyInput(t *testing.T) {
 }
 
 func TestEncodeTXTRecordStrings_EmptyKey(t *testing.T) {
-	pairs := []txtKeyValue{
+	pairs := []TXTEntry{
 		{Key: "", Value: []byte("bad")},
 	}
 	_, err := encodeTXTRecordStrings(pairs)
@@ -73,14 +73,14 @@ func TestEncodeTXTRecordStrings_MaxLength(t *testing.T) {
 	// Exactly 255 bytes should succeed
 	key := "k"
 	val := strings.Repeat("x", 253) // "k=" + 253 = 255
-	pairs := []txtKeyValue{{Key: key, Value: []byte(val)}}
+	pairs := []TXTEntry{{Key: key, Value: []byte(val)}}
 	strs, err := encodeTXTRecordStrings(pairs)
 	require.NoError(t, err)
 	assert.Equal(t, 255, len(strs[0]))
 
 	// 256 bytes should fail
 	val256 := strings.Repeat("x", 254) // "k=" + 254 = 256
-	pairs256 := []txtKeyValue{{Key: key, Value: []byte(val256)}}
+	pairs256 := []TXTEntry{{Key: key, Value: []byte(val256)}}
 	_, err = encodeTXTRecordStrings(pairs256)
 	assert.ErrorIs(t, err, errTXTStringTooLong)
 }
@@ -88,14 +88,14 @@ func TestEncodeTXTRecordStrings_MaxLength(t *testing.T) {
 func TestEncodeTXTRecordStrings_BooleanMaxLength(t *testing.T) {
 	// Boolean attribute: key only, 255 chars OK
 	key255 := strings.Repeat("a", 255)
-	pairs := []txtKeyValue{{Key: key255, Value: nil}}
+	pairs := []TXTEntry{{Key: key255, Value: nil}}
 	strs, err := encodeTXTRecordStrings(pairs)
 	require.NoError(t, err)
 	assert.Equal(t, 255, len(strs[0]))
 
 	// 256 chars should fail
 	key256 := strings.Repeat("a", 256)
-	pairs256 := []txtKeyValue{{Key: key256, Value: nil}}
+	pairs256 := []TXTEntry{{Key: key256, Value: nil}}
 	_, err = encodeTXTRecordStrings(pairs256)
 	assert.ErrorIs(t, err, errTXTStringTooLong)
 }
@@ -192,7 +192,7 @@ func TestDecodeTXTRecordStrings_SpacesInKey(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestTXTRoundTrip(t *testing.T) {
-	original := []txtKeyValue{
+	original := []TXTEntry{
 		{Key: "txtvers", Value: []byte("1")},
 		{Key: "path", Value: []byte("/")},
 		{Key: "secure", Value: nil},
@@ -212,6 +212,50 @@ func TestTXTRoundTrip(t *testing.T) {
 			assert.Equal(t, kv.Value, decoded[i].Value)
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// TXTEntry constructors
+// ---------------------------------------------------------------------------
+
+func TestNewTXTEntry(t *testing.T) {
+	e := NewTXTEntry("version", "1.2.3")
+	assert.Equal(t, "version", e.Key)
+	assert.Equal(t, []byte("1.2.3"), e.Value)
+
+	// Explicit empty value is non-nil and encodes as "key=".
+	empty := NewTXTEntry("setup", "")
+	assert.Equal(t, "setup", empty.Key)
+	assert.NotNil(t, empty.Value)
+	assert.Empty(t, empty.Value)
+}
+
+func TestNewTXTFlag(t *testing.T) {
+	e := NewTXTFlag("secure")
+	assert.Equal(t, "secure", e.Key)
+	assert.Nil(t, e.Value)
+}
+
+func TestNewTXTConstructors_Encode(t *testing.T) {
+	entries := []TXTEntry{
+		NewTXTEntry("version", "1.2.3"),
+		NewTXTEntry("setup", ""),
+		NewTXTFlag("secure"),
+	}
+
+	strs, err := encodeTXTRecordStrings(entries)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"version=1.2.3", "setup=", "secure"}, strs)
+
+	// Round-trip back to entries.
+	decoded := decodeTXTRecordStrings(strs)
+	require.Len(t, decoded, 3)
+	assert.Equal(t, "version", decoded[0].Key)
+	assert.Equal(t, []byte("1.2.3"), decoded[0].Value)
+	assert.Equal(t, "setup", decoded[1].Key)
+	assert.Equal(t, []byte(""), decoded[1].Value)
+	assert.Equal(t, "secure", decoded[2].Key)
+	assert.Nil(t, decoded[2].Value)
 }
 
 // ---------------------------------------------------------------------------
@@ -447,7 +491,7 @@ func TestAAAARoundTrip(t *testing.T) {
 
 func TestTXTFullRoundTrip(t *testing.T) {
 	// RFC 6763 §6.6 test vector
-	pairs := []txtKeyValue{
+	pairs := []TXTEntry{
 		{Key: "key", Value: []byte("value")},
 		{Key: "paper", Value: []byte("A4")},
 		{Key: "passreq", Value: nil},

--- a/records_test.go
+++ b/records_test.go
@@ -218,16 +218,29 @@ func TestTXTRoundTrip(t *testing.T) {
 // TXTEntry constructors
 // ---------------------------------------------------------------------------
 
-func TestNewTXTEntry(t *testing.T) {
-	e := NewTXTEntry("version", "1.2.3")
+func TestNewTXTString(t *testing.T) {
+	e := NewTXTString("version", "1.2.3")
 	assert.Equal(t, "version", e.Key)
 	assert.Equal(t, []byte("1.2.3"), e.Value)
 
 	// Explicit empty value is non-nil and encodes as "key=".
-	empty := NewTXTEntry("setup", "")
+	empty := NewTXTString("setup", "")
 	assert.Equal(t, "setup", empty.Key)
 	assert.NotNil(t, empty.Value)
 	assert.Empty(t, empty.Value)
+}
+
+func TestNewTXTBinary(t *testing.T) {
+	raw := []byte{0x00, 0x01, 0xff}
+	e := NewTXTBinary("data", raw)
+	assert.Equal(t, "data", e.Key)
+	assert.Equal(t, raw, e.Value)
+
+	// nil bytes are normalized to an explicit empty value ("key="), never a flag.
+	nilVal := NewTXTBinary("data", nil)
+	assert.Equal(t, "data", nilVal.Key)
+	assert.NotNil(t, nilVal.Value)
+	assert.Empty(t, nilVal.Value)
 }
 
 func TestNewTXTFlag(t *testing.T) {
@@ -238,24 +251,83 @@ func TestNewTXTFlag(t *testing.T) {
 
 func TestNewTXTConstructors_Encode(t *testing.T) {
 	entries := []TXTEntry{
-		NewTXTEntry("version", "1.2.3"),
-		NewTXTEntry("setup", ""),
+		NewTXTString("version", "1.2.3"),
+		NewTXTString("setup", ""),
+		NewTXTBinary("data", []byte{0x41, 0x42}),
 		NewTXTFlag("secure"),
 	}
 
 	strs, err := encodeTXTRecordStrings(entries)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"version=1.2.3", "setup=", "secure"}, strs)
+	assert.Equal(t, []string{"version=1.2.3", "setup=", "data=AB", "secure"}, strs)
 
 	// Round-trip back to entries.
 	decoded := decodeTXTRecordStrings(strs)
-	require.Len(t, decoded, 3)
+	require.Len(t, decoded, 4)
 	assert.Equal(t, "version", decoded[0].Key)
 	assert.Equal(t, []byte("1.2.3"), decoded[0].Value)
 	assert.Equal(t, "setup", decoded[1].Key)
 	assert.Equal(t, []byte(""), decoded[1].Value)
-	assert.Equal(t, "secure", decoded[2].Key)
-	assert.Nil(t, decoded[2].Value)
+	assert.Equal(t, "data", decoded[2].Key)
+	assert.Equal(t, []byte("AB"), decoded[2].Value)
+	assert.Equal(t, "secure", decoded[3].Key)
+	assert.Nil(t, decoded[3].Value)
+}
+
+func TestValidateTXTEntries(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		err := validateTXTEntries([]TXTEntry{
+			NewTXTString("version", "1.2.3"),
+			NewTXTString("setup", ""),
+			NewTXTFlag("secure"),
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("nil and empty are valid", func(t *testing.T) {
+		assert.NoError(t, validateTXTEntries(nil))
+		assert.NoError(t, validateTXTEntries([]TXTEntry{}))
+	})
+
+	t.Run("empty key", func(t *testing.T) {
+		err := validateTXTEntries([]TXTEntry{NewTXTString("", "v")})
+		assert.ErrorIs(t, err, errTXTKeyEmpty)
+	})
+
+	t.Run("key with equals", func(t *testing.T) {
+		err := validateTXTEntries([]TXTEntry{{Key: "a=b", Value: []byte("v")}})
+		assert.ErrorIs(t, err, errTXTKeyHasEquals)
+	})
+
+	t.Run("non-ascii key", func(t *testing.T) {
+		err := validateTXTEntries([]TXTEntry{NewTXTString("naïve", "v")})
+		assert.ErrorIs(t, err, errTXTKeyNotASCII)
+	})
+
+	t.Run("control char key", func(t *testing.T) {
+		err := validateTXTEntries([]TXTEntry{NewTXTString("a\x01b", "v")})
+		assert.ErrorIs(t, err, errTXTKeyNotASCII)
+	})
+
+	t.Run("duplicate key case-insensitive", func(t *testing.T) {
+		err := validateTXTEntries([]TXTEntry{
+			NewTXTString("version", "1"),
+			NewTXTString("VERSION", "2"),
+		})
+		assert.ErrorIs(t, err, errTXTDuplicateKey)
+	})
+
+	t.Run("encoded string too long", func(t *testing.T) {
+		// "k=" + 254 bytes = 256 > 255.
+		err := validateTXTEntries([]TXTEntry{NewTXTString("k", strings.Repeat("x", 254))})
+		assert.ErrorIs(t, err, errTXTStringTooLong)
+	})
+
+	t.Run("max length boundary", func(t *testing.T) {
+		// "k=" + 253 bytes = 255, exactly the limit.
+		err := validateTXTEntries([]TXTEntry{NewTXTString("k", strings.Repeat("x", 253))})
+		assert.NoError(t, err)
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/server_test.go
+++ b/server_test.go
@@ -8,6 +8,7 @@ package mdns
 import (
 	"net"
 	"net/netip"
+	"strings"
 	"testing"
 
 	"github.com/pion/logging"
@@ -732,6 +733,54 @@ func TestWithServiceInvalidServiceName(t *testing.T) {
 	assert.Empty(t, cfg.services)
 }
 
+func TestWithServiceValidTXT(t *testing.T) {
+	cfg := &serverConfig{}
+	opt := WithService(ServiceInstance{
+		Instance: "My Web",
+		Service:  "_http._tcp",
+		Port:     8080,
+		Text: []TXTEntry{
+			NewTXTString("version", "1.2.3"),
+			NewTXTFlag("secure"),
+		},
+	})
+	err := opt.applyServer(cfg)
+
+	assert.NoError(t, err)
+	require.Len(t, cfg.services, 1)
+	assert.Len(t, cfg.services[0].Text, 2)
+}
+
+func TestWithServiceInvalidTXT(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    []TXTEntry
+		wantErr error
+	}{
+		{"key with equals", []TXTEntry{{Key: "a=b", Value: []byte("v")}}, errTXTKeyHasEquals},
+		{"empty key", []TXTEntry{NewTXTString("", "v")}, errTXTKeyEmpty},
+		{"non-ascii key", []TXTEntry{NewTXTString("naïve", "v")}, errTXTKeyNotASCII},
+		{"duplicate key", []TXTEntry{NewTXTString("k", "1"), NewTXTString("K", "2")}, errTXTDuplicateKey},
+		{"too long", []TXTEntry{NewTXTString("k", strings.Repeat("x", 254))}, errTXTStringTooLong},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &serverConfig{}
+			opt := WithService(ServiceInstance{
+				Instance: "My Web",
+				Service:  "_http._tcp",
+				Port:     8080,
+				Text:     tt.text,
+			})
+			err := opt.applyServer(cfg)
+
+			assert.ErrorIs(t, err, tt.wantErr)
+			assert.Empty(t, cfg.services, "invalid service should not be registered")
+		})
+	}
+}
+
 func TestWithServiceMultiple(t *testing.T) {
 	cfg := &serverConfig{}
 
@@ -1045,8 +1094,8 @@ func TestCreateServiceAnswerTXTWithEntries(t *testing.T) {
 		Host:     "myhost.local.",
 		Port:     8080,
 		Text: []TXTEntry{
-			NewTXTEntry("version", "1.2.3"),
-			NewTXTEntry("setup", ""),
+			NewTXTString("version", "1.2.3"),
+			NewTXTString("setup", ""),
 			NewTXTFlag("secure"),
 		},
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/dns/dnsmessage"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
@@ -1033,6 +1034,37 @@ func TestCreateServiceAnswerTXT(t *testing.T) {
 	assert.Len(t, msg.Answers, 1)
 	assert.Equal(t, dnsmessage.TypeTXT, msg.Answers[0].Header.Type)
 	assert.Empty(t, msg.Additionals, "TXT answers should have no additional records")
+}
+
+func TestCreateServiceAnswerTXTWithEntries(t *testing.T) {
+	srv := &server{ttl: 120}
+	svc := &ServiceInstance{
+		Instance: "My Web",
+		Service:  "_http._tcp",
+		Domain:   "local",
+		Host:     "myhost.local.",
+		Port:     8080,
+		Text: []TXTEntry{
+			NewTXTEntry("version", "1.2.3"),
+			NewTXTEntry("setup", ""),
+			NewTXTFlag("secure"),
+		},
+	}
+	question := dnsmessage.Question{
+		Name:  dnsmessage.MustNewName("My Web._http._tcp.local."),
+		Type:  dnsmessage.TypeTXT,
+		Class: dnsmessage.ClassINET,
+	}
+	addr := netip.MustParseAddr("192.168.1.100")
+
+	msg, err := srv.createServiceAnswer(1234, question, svc, addr, false)
+	require.NoError(t, err)
+	require.Len(t, msg.Answers, 1)
+	assert.Equal(t, dnsmessage.TypeTXT, msg.Answers[0].Header.Type)
+
+	txts, err := parseTXTData(msg.Answers[0].Body)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"version=1.2.3", "setup=", "secure"}, txts)
 }
 
 func TestCreateServiceAnswerUnicast(t *testing.T) {


### PR DESCRIPTION
## Summary

The DNS-SD server support (#253) lets callers advertise a service with `WithService`, but `ServiceInstance.Text` used the unexported `txtKeyValue` element type — so external callers had no exported type, constructor, or setter to populate TXT records. The server already serialized `Text` and `Browse()` already decoded into it; the only missing piece was the public API to construct entries.

This renames `txtKeyValue` → the exported `TXTEntry` and adds two ergonomic constructors that hide the nil-vs-empty `Value` footgun.

### Before

```go
// Impossible from outside the package — txtKeyValue is unexported.
mdns.WithService(mdns.ServiceInstance{
    Instance: "My Web Server",
    Service:  "_http._tcp",
    Port:     8080,
    // Text: ??? no exported element type
})
```

### After

```go
mdns.WithService(mdns.ServiceInstance{
    Instance: "My Web Server",
    Service:  "_http._tcp",
    Port:     8080,
    Text: []mdns.TXTEntry{
        mdns.NewTXTEntry("version", "1.2.3"), // "version=1.2.3"
        mdns.NewTXTEntry("setup", ""),         // "setup="
        mdns.NewTXTFlag("secure"),             // "secure" (boolean attr)
    },
})
```

## Backward compatibility

Fully backward-compatible: `txtKeyValue` was never exported, so no external caller could reference it. Existing validation (non-empty key, 255-byte per-string limit, case-insensitive dedup keeping first) is unchanged.

## Tests

- `TestNewTXTEntry` / `TestNewTXTFlag` — constructor semantics, incl. explicit empty value (`key=`) vs boolean flag (nil → bare `key`)
- `TestNewTXTConstructors_Encode` — entries → wire strings → decode round-trip
- `TestCreateServiceAnswerTXTWithEntries` — server emits the configured TXT entries in its TXT answer
- e2e `testReverse` now advertises a TXT entry + flag against avahi-browse

Refs #253