### PR TITLE
Add service removed events to Browse

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -242,13 +242,20 @@ func (c *cache) lookup(name string, rrType dnsmessage.Type, rrClass dnsmessage.C
 	return results
 }
 
-// sweep removes all expired entries from the cache.
-func (c *cache) sweep() {
+// sweep removes all expired entries from the cache and returns the
+// removed resources, so that callers can surface removals (e.g. browse
+// "service removed" events). Sweep is the only place that reports
+// removals: goodbye packets (§10.1) and cache-flush replacements
+// (§10.2) shorten expiry rather than deleting, so they too surface
+// here once their grace period passes.
+func (c *cache) sweep() []dnsmessage.Resource {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	now := c.now()
 	size := 0
+
+	var expired []dnsmessage.Resource
 
 	for key, entries := range c.entries {
 		var alive []cacheEntry
@@ -256,6 +263,8 @@ func (c *cache) sweep() {
 		for _, entry := range entries {
 			if now.Before(entry.expiresAt) {
 				alive = append(alive, entry)
+			} else {
+				expired = append(expired, entry.resource)
 			}
 		}
 
@@ -268,6 +277,8 @@ func (c *cache) sweep() {
 	}
 
 	c.size = size
+
+	return expired
 }
 
 // refreshThresholds returns the fractions of TTL at which refresh queries

--- a/cache_test.go
+++ b/cache_test.go
@@ -315,6 +315,66 @@ func TestCacheSweepEmpty(t *testing.T) {
 	assert.Equal(t, 0, ca.len())
 }
 
+func TestSweepReturnsExpiredEntries(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+
+	ca.insert(mustBuildPTR(t, "_http._tcp.local.", "My Web._http._tcp.local.", 60), clock.now())
+	ca.insert(mustBuildA(t, "alive.local.", "10.0.0.2", 300), clock.now())
+	clock.advance(120 * time.Second)
+
+	expired := ca.sweep()
+	require.Len(t, expired, 1)
+	assert.Equal(t, "_http._tcp.local.", expired[0].Header.Name.String())
+	assert.Equal(t, dnsmessage.TypePTR, expired[0].Header.Type)
+
+	target, err := parsePTRTarget(expired[0].Body)
+	require.NoError(t, err)
+	assert.Equal(t, "My Web._http._tcp.local.", target)
+
+	// A second sweep has nothing left to report.
+	assert.Empty(t, ca.sweep())
+}
+
+func TestSweepReturnsGoodbyeAfterRetention(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+
+	ca.insert(mustBuildPTR(t, "_http._tcp.local.", "My Web._http._tcp.local.", 4500), clock.now())
+
+	// Goodbye for the same rdata: retained for 1s (§10.1), not yet swept.
+	ca.insert(mustBuildPTR(t, "_http._tcp.local.", "My Web._http._tcp.local.", 0), clock.now())
+	assert.Empty(t, ca.sweep())
+
+	clock.advance(1500 * time.Millisecond)
+
+	expired := ca.sweep()
+	require.Len(t, expired, 1)
+	assert.Equal(t, dnsmessage.TypePTR, expired[0].Header.Type)
+
+	target, err := parsePTRTarget(expired[0].Body)
+	require.NoError(t, err)
+	assert.Equal(t, "My Web._http._tcp.local.", target)
+}
+
+func TestCapEvictionNotReported(t *testing.T) {
+	clock := newTestClock()
+	ca := newCache(clock.now)
+
+	// Short-lived record that will be the cap-eviction victim.
+	ca.insert(mustBuildA(t, "victim.local.", "10.0.0.1", 5), clock.now())
+
+	for i := range maxCacheEntries {
+		name := fmt.Sprintf("host%d.local.", i)
+		ca.insert(mustBuildA(t, name, "10.0.0.2", 100), clock.now())
+	}
+
+	// The victim was evicted for capacity, not absence: sweep must not
+	// report it (the record may still be alive on the network).
+	assert.Empty(t, ca.lookup("victim.local.", dnsmessage.TypeA, dnsmessage.ClassINET))
+	assert.Empty(t, ca.sweep())
+}
+
 // ---------------------------------------------------------------------------
 // TTL update — same rdata, new TTL
 // ---------------------------------------------------------------------------

--- a/client.go
+++ b/client.go
@@ -295,6 +295,21 @@ func (h *answerHandler) monitoredCacheKeys() []cacheKey {
 	return keys
 }
 
+// handleExpired forwards resources that expired out of the record cache
+// to active browse sessions so they can emit ServiceRemoved events.
+func (h *answerHandler) handleExpired(expired []dnsmessage.Resource) {
+	h.mu.RLock()
+	browseSessions := make([]*browseSession, len(h.browseSessions))
+	copy(browseSessions, h.browseSessions)
+	h.mu.RUnlock()
+
+	for _, res := range expired {
+		for _, session := range browseSessions {
+			session.handleExpired(res)
+		}
+	}
+}
+
 // handle processes a DNS message containing answers.
 // It matches answers against registered name queries, active browse sessions,
 // and active enumerate sessions.
@@ -425,8 +440,8 @@ type browseSession struct {
 	serviceType string // e.g. "_http._tcp"
 	domain      string // e.g. "local"
 	emit        func(ServiceEvent)
-	seen        map[string]bool             // instance names already emitted
 	pending     map[string]*pendingInstance // instances being assembled
+	active      map[string]*pendingInstance // instances already emitted
 	mu          sync.Mutex
 	done        chan struct{}
 	cancel      context.CancelFunc
@@ -446,8 +461,8 @@ func newBrowseSession(ctx context.Context, serviceType string, emit func(Service
 		serviceType: serviceType,
 		domain:      "local",
 		emit:        emit,
-		seen:        make(map[string]bool),
 		pending:     make(map[string]*pendingInstance),
+		active:      make(map[string]*pendingInstance),
 		done:        done,
 		cancel:      cancel,
 	}
@@ -460,7 +475,10 @@ func (bs *browseSession) serviceName() string {
 
 // monitoredCacheKeys returns cache keys for records this browse session
 // is actively monitoring: the PTR for the service type, plus SRV/TXT/A/AAAA
-// keys for known instances.
+// keys for pending and already-emitted instances. Keeping emitted
+// instances monitored means their records are refreshed while the
+// service is alive (RFC 6762 §5.2) and expire when it is gone, which
+// drives ServiceRemoved events.
 func (bs *browseSession) monitoredCacheKeys() []cacheKey {
 	bs.mu.Lock()
 	defer bs.mu.Unlock()
@@ -471,14 +489,13 @@ func (bs *browseSession) monitoredCacheKeys() []cacheKey {
 		{name: svcName, rrType: dnsmessage.TypePTR, rrClass: dnsmessage.ClassINET},
 	}
 
-	// Add keys for pending instances.
 	for _, inst := range bs.pending {
 		keys = append(keys, bs.instanceCacheKeys(inst)...)
 	}
 
-	// Add keys for already-seen instances (they remain in the seen map).
-	// We don't track full details for emitted instances, but the PTR key
-	// above covers rediscovery.
+	for _, inst := range bs.active {
+		keys = append(keys, bs.instanceCacheKeys(inst)...)
+	}
 
 	return keys
 }
@@ -507,31 +524,32 @@ func (bs *browseSession) instanceCacheKeys(inst *pendingInstance) []cacheKey {
 }
 
 // processRecord updates the browse session with a received DNS resource record.
-// Returns true if a new complete instance was emitted.
-//
-//nolint:cyclop
-func (bs *browseSession) processRecord(answer dnsmessage.Resource, zone string) bool {
+func (bs *browseSession) processRecord(answer dnsmessage.Resource, zone string) {
 	bs.mu.Lock()
 	defer bs.mu.Unlock()
 
 	switch answer.Header.Type {
 	case dnsmessage.TypePTR:
 		bs.handlePTRRecord(answer)
-
-		return false
 	case dnsmessage.TypeSRV:
-		return bs.handleSRVRecord(answer, zone)
+		bs.handleSRVRecord(answer, zone)
 	case dnsmessage.TypeTXT:
-		return bs.handleTXTRecord(answer)
+		bs.handleTXTRecord(answer)
 	case dnsmessage.TypeA, dnsmessage.TypeAAAA:
-		return bs.handleAddressRecord(answer, zone)
+		bs.handleAddressRecord(answer, zone)
 	default:
-		return false
 	}
 }
 
 // handlePTRRecord processes a PTR answer for this browse session.
+// Goodbye PTRs (TTL=0, RFC 6762 §10.1) are skipped: they must not start
+// resolving a new instance, and removal of a known instance is driven
+// by cache expiry (handleExpired), not by the goodbye itself.
 func (bs *browseSession) handlePTRRecord(answer dnsmessage.Resource) {
+	if answer.Header.TTL == 0 {
+		return
+	}
+
 	target, err := parsePTRTarget(answer.Body)
 	if err != nil {
 		return
@@ -542,7 +560,7 @@ func (bs *browseSession) handlePTRRecord(answer dnsmessage.Resource) {
 		return
 	}
 
-	if bs.seen[instance] {
+	if _, emitted := bs.active[instance]; emitted {
 		return
 	}
 
@@ -556,15 +574,15 @@ func (bs *browseSession) handlePTRRecord(answer dnsmessage.Resource) {
 }
 
 // handleSRVRecord processes an SRV answer.
-func (bs *browseSession) handleSRVRecord(answer dnsmessage.Resource, zone string) bool {
+func (bs *browseSession) handleSRVRecord(answer dnsmessage.Resource, zone string) {
 	target, port, priority, weight, err := parseSRVData(answer.Body)
 	if err != nil {
-		return false
+		return
 	}
 
 	inst := bs.findPendingByInstanceName(answer.Header.Name.String())
 	if inst == nil {
-		return false
+		return
 	}
 
 	inst.host = target
@@ -573,39 +591,38 @@ func (bs *browseSession) handleSRVRecord(answer dnsmessage.Resource, zone string
 	inst.weight = weight
 	inst.hasSRV = true
 
-	return bs.tryEmit(inst, zone)
+	bs.tryEmit(inst, zone)
 }
 
 // handleTXTRecord processes a TXT answer.
-func (bs *browseSession) handleTXTRecord(answer dnsmessage.Resource) bool {
+func (bs *browseSession) handleTXTRecord(answer dnsmessage.Resource) {
 	txts, err := parseTXTData(answer.Body)
 	if err != nil {
-		return false
+		return
 	}
 
 	inst := bs.findPendingByInstanceName(answer.Header.Name.String())
 	if inst == nil {
-		return false
+		return
 	}
 
 	inst.text = decodeTXTRecordStrings(txts)
 	inst.hasTXT = true
 
-	return bs.tryEmit(inst, "")
+	bs.tryEmit(inst, "")
 }
 
 // handleAddressRecord processes an A or AAAA answer.
-func (bs *browseSession) handleAddressRecord(answer dnsmessage.Resource, zone string) bool {
+func (bs *browseSession) handleAddressRecord(answer dnsmessage.Resource, zone string) {
 	addr, err := addrFromAnswer(answer)
 	if err != nil {
-		return false
+		return
 	}
 
 	resultAddr := addrWithOptionalZone(*addr, zone)
 
 	// Match against any pending instance whose host matches this answer name.
 	answerName := answer.Header.Name.String()
-	emitted := false
 	for _, inst := range bs.pending {
 		if !inst.hasSRV {
 			continue
@@ -617,12 +634,8 @@ func (bs *browseSession) handleAddressRecord(answer dnsmessage.Resource, zone st
 		inst.addr = resultAddr
 		inst.hasAddr = true
 
-		if bs.tryEmit(inst, zone) {
-			emitted = true
-		}
+		bs.tryEmit(inst, zone)
 	}
-
-	return emitted
 }
 
 // findPendingByInstanceName finds a pending instance matching the given FQDN.
@@ -640,26 +653,80 @@ func (bs *browseSession) findPendingByInstanceName(name string) *pendingInstance
 	return nil
 }
 
-// tryEmit fires the callback if the instance is complete and not yet emitted.
-func (bs *browseSession) tryEmit(inst *pendingInstance, zone string) bool {
+// tryEmit fires the callback if the instance is complete and not yet
+// emitted. Emitted instances move from pending to active so their
+// records stay monitored and a later disappearance can be reported.
+func (bs *browseSession) tryEmit(inst *pendingInstance, zone string) {
 	if !inst.isComplete() {
-		return false
+		return
 	}
-	if bs.seen[inst.instance] {
-		return false
+	if _, emitted := bs.active[inst.instance]; emitted {
+		return
 	}
-
-	bs.seen[inst.instance] = true
 
 	if zone != "" {
 		inst.addr = addrWithOptionalZone(inst.addr, zone)
 	}
 
-	evt := inst.toServiceEvent()
-	bs.emit(evt)
+	bs.active[inst.instance] = inst
 	delete(bs.pending, inst.instance)
 
-	return true
+	evt := inst.toServiceEvent()
+	bs.emit(evt)
+}
+
+// handleExpired processes a resource that expired out of the record
+// cache. When the expired record is the PTR naming an instance of this
+// session's service, that instance is gone (goodbye packet or
+// unrefreshed TTL): an active instance produces a ServiceRemoved event
+// and becomes eligible for rediscovery; a pending one is silently
+// dropped. Non-PTR expirations are ignored — the instance PTR is the
+// canonical "instance exists" record for browsing (RFC 6763 §4.1).
+func (bs *browseSession) handleExpired(res dnsmessage.Resource) {
+	if res.Header.Type != dnsmessage.TypePTR {
+		return
+	}
+
+	if !strings.EqualFold(res.Header.Name.String(), bs.serviceName()) {
+		return
+	}
+
+	target, err := parsePTRTarget(res.Body)
+	if err != nil {
+		return
+	}
+
+	instance, _, _, err := parseServiceInstanceName(target)
+	if err != nil {
+		return
+	}
+
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+
+	bs.removeInstanceLocked(instance)
+}
+
+// removeInstanceLocked drops the named instance (case-insensitive) and
+// emits ServiceRemoved if it had been reported. Caller must hold bs.mu.
+func (bs *browseSession) removeInstanceLocked(instance string) {
+	for name := range bs.pending {
+		if strings.EqualFold(name, instance) {
+			delete(bs.pending, name)
+		}
+	}
+
+	for name, inst := range bs.active {
+		if !strings.EqualFold(name, instance) {
+			continue
+		}
+
+		delete(bs.active, name)
+
+		evt := inst.toServiceEvent()
+		evt.Type = ServiceRemoved
+		bs.emit(evt)
+	}
 }
 
 // enumerateSession tracks the state of an active EnumerateServiceTypes call.

--- a/client.go
+++ b/client.go
@@ -295,6 +295,21 @@ func (h *answerHandler) monitoredCacheKeys() []cacheKey {
 	return keys
 }
 
+// handleExpired forwards resources that expired out of the record cache
+// to active browse sessions so they can emit ServiceRemoved events.
+func (h *answerHandler) handleExpired(expired []dnsmessage.Resource) {
+	h.mu.RLock()
+	browseSessions := make([]*browseSession, len(h.browseSessions))
+	copy(browseSessions, h.browseSessions)
+	h.mu.RUnlock()
+
+	for _, res := range expired {
+		for _, session := range browseSessions {
+			session.handleExpired(res)
+		}
+	}
+}
+
 // handle processes a DNS message containing answers.
 // It matches answers against registered name queries, active browse sessions,
 // and active enumerate sessions.
@@ -425,8 +440,9 @@ type browseSession struct {
 	serviceType string // e.g. "_http._tcp"
 	domain      string // e.g. "local"
 	emit        func(ServiceEvent)
-	seen        map[string]ServiceEvent     // last event emitted for each instance
+	seen        map[string]ServiceEvent     // last event delivered for each instance
 	pending     map[string]*pendingInstance // instances being assembled
+	active      map[string]*pendingInstance // instances already emitted
 	mu          sync.Mutex
 	done        chan struct{}
 	cancel      context.CancelFunc
@@ -448,6 +464,7 @@ func newBrowseSession(ctx context.Context, serviceType string, emit func(Service
 		emit:        emit,
 		seen:        make(map[string]ServiceEvent),
 		pending:     make(map[string]*pendingInstance),
+		active:      make(map[string]*pendingInstance),
 		done:        done,
 		cancel:      cancel,
 	}
@@ -460,7 +477,10 @@ func (bs *browseSession) serviceName() string {
 
 // monitoredCacheKeys returns cache keys for records this browse session
 // is actively monitoring: the PTR for the service type, plus SRV/TXT/A/AAAA
-// keys for known instances.
+// keys for pending and already-emitted instances. Keeping emitted
+// instances monitored means their records are refreshed while the
+// service is alive (RFC 6762 §5.2) and expire when it is gone, which
+// drives ServiceRemoved events.
 func (bs *browseSession) monitoredCacheKeys() []cacheKey {
 	bs.mu.Lock()
 	defer bs.mu.Unlock()
@@ -471,14 +491,13 @@ func (bs *browseSession) monitoredCacheKeys() []cacheKey {
 		{name: svcName, rrType: dnsmessage.TypePTR, rrClass: dnsmessage.ClassINET},
 	}
 
-	// Add keys for pending instances.
 	for _, inst := range bs.pending {
 		keys = append(keys, bs.instanceCacheKeys(inst)...)
 	}
 
-	// Add keys for already-seen instances (they remain in the seen map).
-	// We don't track full details for emitted instances, but the PTR key
-	// above covers rediscovery.
+	for _, inst := range bs.active {
+		keys = append(keys, bs.instanceCacheKeys(inst)...)
+	}
 
 	return keys
 }
@@ -507,31 +526,32 @@ func (bs *browseSession) instanceCacheKeys(inst *pendingInstance) []cacheKey {
 }
 
 // processRecord updates the browse session with a received DNS resource record.
-// Returns true if a new complete instance was emitted.
-//
-//nolint:cyclop
-func (bs *browseSession) processRecord(answer dnsmessage.Resource, zone string) bool {
+func (bs *browseSession) processRecord(answer dnsmessage.Resource, zone string) {
 	bs.mu.Lock()
 	defer bs.mu.Unlock()
 
 	switch answer.Header.Type {
 	case dnsmessage.TypePTR:
 		bs.handlePTRRecord(answer)
-
-		return false
 	case dnsmessage.TypeSRV:
-		return bs.handleSRVRecord(answer, zone)
+		bs.handleSRVRecord(answer, zone)
 	case dnsmessage.TypeTXT:
-		return bs.handleTXTRecord(answer)
+		bs.handleTXTRecord(answer)
 	case dnsmessage.TypeA, dnsmessage.TypeAAAA:
-		return bs.handleAddressRecord(answer, zone)
+		bs.handleAddressRecord(answer, zone)
 	default:
-		return false
 	}
 }
 
 // handlePTRRecord processes a PTR answer for this browse session.
+// Goodbye PTRs (TTL=0, RFC 6762 §10.1) are skipped: they must not start
+// resolving a new instance, and removal of a known instance is driven
+// by cache expiry (handleExpired), not by the goodbye itself.
 func (bs *browseSession) handlePTRRecord(answer dnsmessage.Resource) {
+	if answer.Header.TTL == 0 {
+		return
+	}
+
 	target, err := parsePTRTarget(answer.Body)
 	if err != nil {
 		return
@@ -542,10 +562,13 @@ func (bs *browseSession) handlePTRRecord(answer dnsmessage.Resource) {
 		return
 	}
 
+	// An already-emitted instance keeps being tracked in bs.active; a
+	// repeated PTR must not restart its assembly.
+	if _, emitted := bs.active[instance]; emitted {
+		return
+	}
+
 	if _, exists := bs.pending[instance]; !exists {
-		if _, seen := bs.seen[instance]; seen {
-			return
-		}
 		bs.pending[instance] = &pendingInstance{
 			instance: instance,
 			service:  service,
@@ -555,15 +578,15 @@ func (bs *browseSession) handlePTRRecord(answer dnsmessage.Resource) {
 }
 
 // handleSRVRecord processes an SRV answer.
-func (bs *browseSession) handleSRVRecord(answer dnsmessage.Resource, zone string) bool {
+func (bs *browseSession) handleSRVRecord(answer dnsmessage.Resource, zone string) {
 	target, port, priority, weight, err := parseSRVData(answer.Body)
 	if err != nil {
-		return false
+		return
 	}
 
-	inst := bs.findPendingByInstanceName(answer.Header.Name.String())
+	inst := bs.findTrackedByInstanceName(answer.Header.Name.String())
 	if inst == nil {
-		return false
+		return
 	}
 
 	inst.host = target
@@ -572,77 +595,84 @@ func (bs *browseSession) handleSRVRecord(answer dnsmessage.Resource, zone string
 	inst.weight = weight
 	inst.hasSRV = true
 
-	return bs.tryEmit(inst, zone)
+	bs.tryEmit(inst, zone)
 }
 
 // handleTXTRecord processes a TXT answer.
-func (bs *browseSession) handleTXTRecord(answer dnsmessage.Resource) bool {
+func (bs *browseSession) handleTXTRecord(answer dnsmessage.Resource) {
 	txts, err := parseTXTData(answer.Body)
 	if err != nil {
-		return false
+		return
 	}
 
-	inst := bs.findPendingByInstanceName(answer.Header.Name.String())
+	inst := bs.findTrackedByInstanceName(answer.Header.Name.String())
 	if inst == nil {
-		return false
+		return
 	}
 
 	inst.text = decodeTXTRecordStrings(txts)
 	inst.hasTXT = true
 
-	return bs.tryEmit(inst, "")
+	bs.tryEmit(inst, "")
 }
 
 // handleAddressRecord processes an A or AAAA answer.
-func (bs *browseSession) handleAddressRecord(answer dnsmessage.Resource, zone string) bool {
+func (bs *browseSession) handleAddressRecord(answer dnsmessage.Resource, zone string) {
 	addr, err := addrFromAnswer(answer)
 	if err != nil {
-		return false
+		return
 	}
 
 	resultAddr := addrWithOptionalZone(*addr, zone)
 
-	// Match against any pending instance whose host matches this answer name.
+	// Match against any tracked instance whose host matches this answer name.
+	// Active instances are included so an address change raises ServiceUpdated.
 	answerName := answer.Header.Name.String()
-	emitted := false
-	for _, inst := range bs.pending {
-		if !inst.hasSRV {
-			continue
-		}
-		if !strings.EqualFold(inst.host, answerName) {
-			continue
-		}
+	for _, insts := range []map[string]*pendingInstance{bs.pending, bs.active} {
+		for _, inst := range insts {
+			if !inst.hasSRV {
+				continue
+			}
+			if !strings.EqualFold(inst.host, answerName) {
+				continue
+			}
 
-		inst.addr = resultAddr
-		inst.hasAddr = true
+			inst.addr = resultAddr
+			inst.hasAddr = true
 
-		if bs.tryEmit(inst, zone) {
-			emitted = true
+			bs.tryEmit(inst, zone)
 		}
 	}
-
-	return emitted
 }
 
-// findPendingByInstanceName finds a pending instance matching the given FQDN.
-func (bs *browseSession) findPendingByInstanceName(name string) *pendingInstance {
-	for _, inst := range bs.pending {
-		fqdn := inst.instance
-		if inst.service != "" {
-			fqdn = escapeInstanceName(inst.instance) + "." + inst.service + "." + inst.domain + "."
-		}
-		if strings.EqualFold(fqdn, name) {
-			return inst
+// findTrackedByInstanceName finds a pending or already-emitted instance
+// matching the given FQDN. Active instances are included so that records
+// arriving after the first emit are folded into the tracked state and can
+// raise a ServiceUpdated event.
+func (bs *browseSession) findTrackedByInstanceName(name string) *pendingInstance {
+	for _, insts := range []map[string]*pendingInstance{bs.pending, bs.active} {
+		for _, inst := range insts {
+			fqdn := inst.instance
+			if inst.service != "" {
+				fqdn = escapeInstanceName(inst.instance) + "." + inst.service + "." + inst.domain + "."
+			}
+			if strings.EqualFold(fqdn, name) {
+				return inst
+			}
 		}
 	}
 
 	return nil
 }
 
-// tryEmit fires the callback when a complete instance is first resolved or changes.
-func (bs *browseSession) tryEmit(inst *pendingInstance, zone string) bool {
+// tryEmit fires the callback when a complete instance is first resolved
+// (ServiceAdded) or when a monitored instance's records change
+// (ServiceUpdated). Emitted instances move from pending to active so
+// their records stay monitored and a later disappearance can be
+// reported.
+func (bs *browseSession) tryEmit(inst *pendingInstance, zone string) {
 	if !inst.isComplete() {
-		return false
+		return
 	}
 
 	if zone != "" {
@@ -650,19 +680,88 @@ func (bs *browseSession) tryEmit(inst *pendingInstance, zone string) bool {
 	}
 
 	evt := inst.toServiceEvent()
+
+	// bs.seen holds the last event delivered for this instance, snapshotted
+	// by value: inst is mutated in place by later records, so the previous
+	// state cannot be re-derived from it.
 	previous, seen := bs.seen[inst.instance]
 	if seen && serviceEventsEqual(previous, evt) {
-		return false
+		return
 	}
 	if seen {
 		evt.Type = ServiceUpdated
 	} else {
 		evt.Type = ServiceAdded
 	}
+
+	bs.active[inst.instance] = inst
+	delete(bs.pending, inst.instance)
+
 	bs.seen[inst.instance] = cloneServiceEvent(evt)
 	bs.emit(cloneServiceEvent(evt))
+}
 
-	return true
+// handleExpired processes a resource that expired out of the record
+// cache. When the expired record is the PTR naming an instance of this
+// session's service, that instance is gone (goodbye packet or
+// unrefreshed TTL): an active instance produces a ServiceRemoved event
+// and becomes eligible for rediscovery; a pending one is silently
+// dropped. Non-PTR expirations are ignored — the instance PTR is the
+// canonical "instance exists" record for browsing (RFC 6763 §4.1).
+func (bs *browseSession) handleExpired(res dnsmessage.Resource) {
+	if res.Header.Type != dnsmessage.TypePTR {
+		return
+	}
+
+	if !strings.EqualFold(res.Header.Name.String(), bs.serviceName()) {
+		return
+	}
+
+	target, err := parsePTRTarget(res.Body)
+	if err != nil {
+		return
+	}
+
+	instance, _, _, err := parseServiceInstanceName(target)
+	if err != nil {
+		return
+	}
+
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+
+	bs.removeInstanceLocked(instance)
+}
+
+// removeInstanceLocked drops the named instance (case-insensitive) and
+// emits ServiceRemoved if it had been reported. The bs.seen entry is
+// dropped too, so an instance that comes back is reported as
+// ServiceAdded rather than ServiceUpdated. Caller must hold bs.mu.
+func (bs *browseSession) removeInstanceLocked(instance string) {
+	for name := range bs.pending {
+		if strings.EqualFold(name, instance) {
+			delete(bs.pending, name)
+		}
+	}
+
+	for name := range bs.active {
+		if !strings.EqualFold(name, instance) {
+			continue
+		}
+
+		delete(bs.active, name)
+
+		// The last delivered event is the authoritative "last known
+		// state" for the removal payload.
+		evt, seen := bs.seen[name]
+		delete(bs.seen, name)
+		if !seen {
+			continue
+		}
+
+		evt.Type = ServiceRemoved
+		bs.emit(cloneServiceEvent(evt))
+	}
 }
 
 func serviceEventsEqual(a, b ServiceEvent) bool {

--- a/client_test.go
+++ b/client_test.go
@@ -1059,39 +1059,9 @@ func TestEnumerateSessionMonitoredKeys(t *testing.T) {
 // ---------------------------------------------------------------------------
 // Service removed events (RFC 6762 §10.1 goodbye, TTL expiry)
 // ---------------------------------------------------------------------------
-
-// collectEvents returns an emit callback that records events, plus an
-// accessor returning a snapshot of everything emitted so far.
-func collectEvents() (func(ServiceEvent), func() []ServiceEvent) {
-	var mu sync.Mutex
-	var events []ServiceEvent
-
-	emit := func(evt ServiceEvent) {
-		mu.Lock()
-		defer mu.Unlock()
-		events = append(events, evt)
-	}
-	snapshot := func() []ServiceEvent {
-		mu.Lock()
-		defer mu.Unlock()
-
-		return append([]ServiceEvent(nil), events...)
-	}
-
-	return emit, snapshot
-}
-
-// feedInstance drives a browse session through a full PTR → SRV → TXT →
-// A resolution for one "_http._tcp" instance, triggering an emit.
-func feedInstance(t *testing.T, session *browseSession, instance, host, addr string) {
-	t.Helper()
-
-	fqdn := instance + "._http._tcp.local."
-	session.processRecord(mustBuildPTR(t, "_http._tcp.local.", fqdn, 4500), "")
-	session.processRecord(mustBuildSRV(t, fqdn, host, 8080, 120), "")
-	session.processRecord(mustBuildTXT(t, fqdn, []string{"path=/"}, 4500), "")
-	session.processRecord(mustBuildA(t, host, addr, 120), "")
-}
+// The collectEvents and feedInstance helpers live in refresh_test.go,
+// which has no js build constraint, so the WASM build of that file can
+// use them too.
 
 func TestBrowseMonitorsEmittedInstances(t *testing.T) {
 	emit, events := collectEvents()

--- a/client_test.go
+++ b/client_test.go
@@ -1055,3 +1055,331 @@ func TestEnumerateSessionMonitoredKeys(t *testing.T) {
 	assert.Equal(t, "_services._dns-sd._udp.local.", keys[0].name)
 	assert.Equal(t, dnsmessage.TypePTR, keys[0].rrType)
 }
+
+// ---------------------------------------------------------------------------
+// Service removed events (RFC 6762 §10.1 goodbye, TTL expiry)
+// ---------------------------------------------------------------------------
+
+// collectEvents returns an emit callback that records events, plus an
+// accessor returning a snapshot of everything emitted so far.
+func collectEvents() (func(ServiceEvent), func() []ServiceEvent) {
+	var mu sync.Mutex
+	var events []ServiceEvent
+
+	emit := func(evt ServiceEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, evt)
+	}
+	snapshot := func() []ServiceEvent {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return append([]ServiceEvent(nil), events...)
+	}
+
+	return emit, snapshot
+}
+
+// feedInstance drives a browse session through a full PTR → SRV → TXT →
+// A resolution for one "_http._tcp" instance, triggering an emit.
+func feedInstance(t *testing.T, session *browseSession, instance, host, addr string) {
+	t.Helper()
+
+	fqdn := instance + "._http._tcp.local."
+	session.processRecord(mustBuildPTR(t, "_http._tcp.local.", fqdn, 4500), "")
+	session.processRecord(mustBuildSRV(t, fqdn, host, 8080, 120), "")
+	session.processRecord(mustBuildTXT(t, fqdn, []string{"path=/"}, 4500), "")
+	session.processRecord(mustBuildA(t, host, addr, 120), "")
+}
+
+func TestBrowseMonitorsEmittedInstances(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+	require.Len(t, events(), 1)
+
+	// The emitted instance's records must stay monitored so refresh
+	// keeps them alive and their expiry is observed: service PTR + SRV +
+	// TXT for the instance, A + AAAA for the host.
+	keys := session.monitoredCacheKeys()
+	require.Len(t, keys, 5)
+
+	typesByName := make(map[string][]dnsmessage.Type)
+	for _, key := range keys {
+		typesByName[key.name] = append(typesByName[key.name], key.rrType)
+	}
+	assert.ElementsMatch(t,
+		[]dnsmessage.Type{dnsmessage.TypeSRV, dnsmessage.TypeTXT},
+		typesByName["my web._http._tcp.local."])
+	assert.ElementsMatch(t,
+		[]dnsmessage.Type{dnsmessage.TypeA, dnsmessage.TypeAAAA},
+		typesByName["myhost.local."])
+}
+
+func TestBrowsePTRGoodbyeCreatesNoPending(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	// A goodbye PTR (TTL=0) for an unknown instance must not start
+	// resolving it.
+	session.processRecord(mustBuildPTR(t, "_http._tcp.local.", "Ghost._http._tcp.local.", 0), "")
+
+	session.mu.Lock()
+	assert.Empty(t, session.pending)
+	session.mu.Unlock()
+	assert.Empty(t, events())
+}
+
+func TestBrowseExpiredPTREmitsRemoved(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	session.handleExpired(mustBuildPTR(t, "_http._tcp.local.", "My Web._http._tcp.local.", 0))
+
+	evts := events()
+	require.Len(t, evts, 2)
+	assert.Equal(t, ServiceAdded, evts[0].Type)
+
+	removed := evts[1]
+	assert.Equal(t, ServiceRemoved, removed.Type)
+	assert.Equal(t, "My Web", removed.Instance.Instance)
+	assert.Equal(t, "_http._tcp", removed.Instance.Service)
+	assert.Equal(t, "myhost.local.", removed.Instance.Host)
+	assert.Equal(t, uint16(8080), removed.Instance.Port)
+	assert.Equal(t, netip.MustParseAddr("192.168.1.100"), removed.Addr)
+}
+
+func TestBrowseExpiredPTRUnknownInstanceNoEvent(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	session.handleExpired(mustBuildPTR(t, "_http._tcp.local.", "Never Seen._http._tcp.local.", 0))
+
+	evts := events()
+	require.Len(t, evts, 1)
+	assert.Equal(t, ServiceAdded, evts[0].Type)
+}
+
+func TestBrowseExpiredPTRPendingInstanceNoEvent(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	// PTR only: the instance stays pending (no SRV/TXT/A yet).
+	session.processRecord(mustBuildPTR(t, "_http._tcp.local.", "Half Done._http._tcp.local.", 4500), "")
+
+	session.handleExpired(mustBuildPTR(t, "_http._tcp.local.", "Half Done._http._tcp.local.", 0))
+
+	assert.Empty(t, events())
+
+	session.mu.Lock()
+	assert.Empty(t, session.pending)
+	session.mu.Unlock()
+}
+
+func TestBrowseExpiredSRVAloneNoRemoval(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	// SRV (or A) expiry without PTR expiry does not signal removal; the
+	// instance PTR is the canonical presence record.
+	session.handleExpired(mustBuildSRV(t, "My Web._http._tcp.local.", "myhost.local.", 8080, 0))
+	session.handleExpired(mustBuildA(t, "myhost.local.", "192.168.1.100", 0))
+
+	require.Len(t, events(), 1)
+	assert.Len(t, session.monitoredCacheKeys(), 5, "instance should remain monitored")
+}
+
+func TestBrowseCacheFlushReplacementNoRemoval(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	clock := newTestClock()
+	recordCache := newCache(clock.now)
+	handler := newAnswerHandler(log, "test", recordCache)
+
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+	handler.registerBrowseSession(session)
+	defer handler.unregisterBrowseSession(session)
+
+	source := &net.UDPAddr{IP: net.IPv4(192, 168, 1, 1), Port: 5353}
+	handler.handle(&messageContext{source: source, timestamp: clock.now()}, buildBrowseResponseMsg(t))
+	require.Len(t, events(), 1)
+
+	// Two seconds later the service moves ports: a replacement SRV with
+	// the cache-flush bit caps the old SRV entry to 1s (§10.2).
+	clock.advance(2 * time.Second)
+	newSRV := mustBuildSRV(t, "My Web._http._tcp.local.", "myhost.local.", 9090, 120)
+	newSRV.Header.Class |= rrClassCacheFlush
+	handler.handle(&messageContext{source: source, timestamp: clock.now()}, &dnsmessage.Message{
+		Header:  dnsmessage.Header{Response: true},
+		Answers: []dnsmessage.Resource{newSRV},
+	})
+
+	// Sweeping past the cap reports the old SRV as expired. Forwarding
+	// that report must not emit a removal: the instance is alive, only
+	// its rdata changed.
+	clock.advance(1500 * time.Millisecond)
+	expired := recordCache.sweep()
+	require.NotEmpty(t, expired)
+	handler.handleExpired(expired)
+
+	evts := events()
+	require.Len(t, evts, 1)
+	assert.Equal(t, ServiceAdded, evts[0].Type)
+}
+
+func TestBrowseRediscoveryAfterRemoval(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+	session.handleExpired(mustBuildPTR(t, "_http._tcp.local.", "My Web._http._tcp.local.", 0))
+
+	// The instance comes back: it must be reported as a fresh add.
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	evts := events()
+	require.Len(t, evts, 3)
+	assert.Equal(t, ServiceAdded, evts[0].Type)
+	assert.Equal(t, ServiceRemoved, evts[1].Type)
+	assert.Equal(t, ServiceAdded, evts[2].Type)
+}
+
+func TestBrowseRemovalIdempotent(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	expiredPTR := mustBuildPTR(t, "_http._tcp.local.", "My Web._http._tcp.local.", 0)
+	session.handleExpired(expiredPTR)
+	session.handleExpired(expiredPTR)
+
+	evts := events()
+	require.Len(t, evts, 2, "second expiry of the same instance must not emit again")
+	assert.Equal(t, ServiceRemoved, evts[1].Type)
+}
+
+func TestBrowseRemovalOneOfTwoInstances(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "Alpha", "host-a.local.", "10.0.0.1")
+	feedInstance(t, session, "Beta", "host-b.local.", "10.0.0.2")
+	require.Len(t, events(), 2)
+
+	session.handleExpired(mustBuildPTR(t, "_http._tcp.local.", "Alpha._http._tcp.local.", 0))
+
+	evts := events()
+	require.Len(t, evts, 3)
+	assert.Equal(t, ServiceRemoved, evts[2].Type)
+	assert.Equal(t, "Alpha", evts[2].Instance.Instance)
+
+	// Beta stays active and monitored: PTR + SRV/TXT + A/AAAA.
+	assert.Len(t, session.monitoredCacheKeys(), 5)
+}
+
+func TestBrowseExpiredPTRCaseInsensitive(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	session.handleExpired(mustBuildPTR(t, "_HTTP._tcp.LOCAL.", "MY WEB._HTTP._tcp.LOCAL.", 0))
+
+	evts := events()
+	require.Len(t, evts, 2)
+	assert.Equal(t, ServiceRemoved, evts[1].Type)
+	assert.Equal(t, "My Web", evts[1].Instance.Instance)
+}
+
+func TestBrowseExpiredPTRMalformedIgnored(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	// PTR header with a non-PTR body: rdata parse fails, no event.
+	session.handleExpired(dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{
+			Name:  dnsmessage.MustNewName("_http._tcp.local."),
+			Type:  dnsmessage.TypePTR,
+			Class: dnsmessage.ClassINET,
+		},
+		Body: &dnsmessage.AResource{A: [4]byte{10, 0, 0, 1}},
+	})
+
+	// PTR target that is not a service instance name: parse fails, no event.
+	session.handleExpired(mustBuildPTR(t, "_http._tcp.local.", "local.", 0))
+
+	require.Len(t, events(), 1)
+	assert.Len(t, session.monitoredCacheKeys(), 5, "instance should remain monitored")
+}
+
+func TestBrowseExpiredOtherServiceIgnored(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	session.handleExpired(mustBuildPTR(t, "_ipp._tcp.local.", "My Web._ipp._tcp.local.", 0))
+
+	require.Len(t, events(), 1)
+	assert.Len(t, session.monitoredCacheKeys(), 5, "instance should remain monitored")
+}
+
+func TestAnswerHandlerHandleExpiredFanOut(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
+
+	emitHTTP, httpEvents := collectEvents()
+	httpSession := newBrowseSession(t.Context(), "_http._tcp", emitHTTP)
+	handler.registerBrowseSession(httpSession)
+
+	emitIPP, ippEvents := collectEvents()
+	ippSession := newBrowseSession(t.Context(), "_ipp._tcp", emitIPP)
+	handler.registerBrowseSession(ippSession)
+
+	enumSession := newEnumerateSession(t.Context(), func(string) {})
+	handler.registerEnumerateSession(enumSession)
+
+	feedInstance(t, httpSession, "Web", "host-a.local.", "10.0.0.1")
+
+	ippFQDN := "Printer._ipp._tcp.local."
+	ippSession.processRecord(mustBuildPTR(t, "_ipp._tcp.local.", ippFQDN, 4500), "")
+	ippSession.processRecord(mustBuildSRV(t, ippFQDN, "host-b.local.", 631, 120), "")
+	ippSession.processRecord(mustBuildTXT(t, ippFQDN, []string{""}, 4500), "")
+	ippSession.processRecord(mustBuildA(t, "host-b.local.", "10.0.0.2", 120), "")
+
+	handler.handleExpired([]dnsmessage.Resource{
+		mustBuildPTR(t, "_http._tcp.local.", "Web._http._tcp.local.", 0),
+		mustBuildPTR(t, "_ipp._tcp.local.", "Printer._ipp._tcp.local.", 0),
+	})
+
+	httpEvts := httpEvents()
+	require.Len(t, httpEvts, 2)
+	assert.Equal(t, ServiceRemoved, httpEvts[1].Type)
+	assert.Equal(t, "Web", httpEvts[1].Instance.Instance)
+
+	ippEvts := ippEvents()
+	require.Len(t, ippEvts, 2)
+	assert.Equal(t, ServiceRemoved, ippEvts[1].Type)
+	assert.Equal(t, "Printer", ippEvts[1].Instance.Instance)
+}
+
+func TestAnswerHandlerHandleExpiredNoSessions(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
+
+	// No sessions registered: must be a no-op, not a panic.
+	handler.handleExpired([]dnsmessage.Resource{
+		mustBuildPTR(t, "_http._tcp.local.", "My Web._http._tcp.local.", 0),
+	})
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1408,3 +1408,95 @@ func TestAnswerHandlerHandleExpiredNoSessions(t *testing.T) {
 		mustBuildPTR(t, "_http._tcp.local.", "My Web._http._tcp.local.", 0),
 	})
 }
+
+// ---------------------------------------------------------------------------
+// Added → Updated → Removed lifecycle (#281 removals over #291 updates)
+// ---------------------------------------------------------------------------
+
+// An instance that changes after being reported raises ServiceUpdated, and a
+// later removal reports the most recent state rather than the original one.
+func TestBrowseUpdateThenRemovalReportsLatestState(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	fqdn := "My Web._http._tcp.local."
+	session.processRecord(mustBuildTXT(t, fqdn, []string{"path=/v2"}, 4500), "")
+
+	session.handleExpired(mustBuildPTR(t, "_http._tcp.local.", fqdn, 0))
+
+	evts := events()
+	require.Len(t, evts, 3)
+	assert.Equal(t, ServiceAdded, evts[0].Type)
+	assert.Equal(t, []TXTEntry{NewTXTString("path", "/")}, evts[0].Instance.Text)
+
+	assert.Equal(t, ServiceUpdated, evts[1].Type)
+	assert.Equal(t, []TXTEntry{NewTXTString("path", "/v2")}, evts[1].Instance.Text)
+
+	assert.Equal(t, ServiceRemoved, evts[2].Type)
+	assert.Equal(t, []TXTEntry{NewTXTString("path", "/v2")}, evts[2].Instance.Text,
+		"the removal must carry the last reported state")
+}
+
+// A record change on an already-emitted instance must still be observed: the
+// instance keeps being tracked after it moves out of the pending map.
+func TestBrowseActiveInstanceSRVChangeEmitsUpdate(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	fqdn := "My Web._http._tcp.local."
+	session.processRecord(mustBuildSRV(t, fqdn, "myhost.local.", 9090, 120), "")
+
+	evts := events()
+	require.Len(t, evts, 2)
+	assert.Equal(t, ServiceUpdated, evts[1].Type)
+	assert.Equal(t, uint16(9090), evts[1].Instance.Port)
+}
+
+// An address change on an already-emitted instance is an update too.
+func TestBrowseActiveInstanceAddressChangeEmitsUpdate(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	session.processRecord(mustBuildA(t, "myhost.local.", "192.168.1.200", 120), "")
+
+	evts := events()
+	require.Len(t, evts, 2)
+	assert.Equal(t, ServiceUpdated, evts[1].Type)
+	assert.Equal(t, netip.MustParseAddr("192.168.1.200"), evts[1].Addr)
+}
+
+// Re-receiving identical records for an emitted instance must stay silent.
+func TestBrowseActiveInstanceUnchangedRecordsStaySilent(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	assert.Len(t, events(), 1)
+}
+
+// After a removal the instance is forgotten entirely, so a change relative to
+// its pre-removal state is reported as a fresh add rather than an update.
+func TestBrowseRediscoveryAfterRemovalIsAddNotUpdate(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+	session.handleExpired(mustBuildPTR(t, "_http._tcp.local.", "My Web._http._tcp.local.", 0))
+
+	// Comes back on a different address.
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.200")
+
+	evts := events()
+	require.Len(t, evts, 3)
+	assert.Equal(t, ServiceRemoved, evts[1].Type)
+	assert.Equal(t, ServiceAdded, evts[2].Type)
+	assert.Equal(t, netip.MustParseAddr("192.168.1.200"), evts[2].Addr)
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1106,39 +1106,9 @@ func TestBrowseSessionTXTUpdate(t *testing.T) {
 // ---------------------------------------------------------------------------
 // Service removed events (RFC 6762 §10.1 goodbye, TTL expiry)
 // ---------------------------------------------------------------------------
-
-// collectEvents returns an emit callback that records events, plus an
-// accessor returning a snapshot of everything emitted so far.
-func collectEvents() (func(ServiceEvent), func() []ServiceEvent) {
-	var mu sync.Mutex
-	var events []ServiceEvent
-
-	emit := func(evt ServiceEvent) {
-		mu.Lock()
-		defer mu.Unlock()
-		events = append(events, evt)
-	}
-	snapshot := func() []ServiceEvent {
-		mu.Lock()
-		defer mu.Unlock()
-
-		return append([]ServiceEvent(nil), events...)
-	}
-
-	return emit, snapshot
-}
-
-// feedInstance drives a browse session through a full PTR → SRV → TXT →
-// A resolution for one "_http._tcp" instance, triggering an emit.
-func feedInstance(t *testing.T, session *browseSession, instance, host, addr string) {
-	t.Helper()
-
-	fqdn := instance + "._http._tcp.local."
-	session.processRecord(mustBuildPTR(t, "_http._tcp.local.", fqdn, 4500), "")
-	session.processRecord(mustBuildSRV(t, fqdn, host, 8080, 120), "")
-	session.processRecord(mustBuildTXT(t, fqdn, []string{"path=/"}, 4500), "")
-	session.processRecord(mustBuildA(t, host, addr, 120), "")
-}
+// The collectEvents and feedInstance helpers live in refresh_test.go,
+// which has no js build constraint, so the WASM build of that file can
+// use them too.
 
 func TestBrowseMonitorsEmittedInstances(t *testing.T) {
 	emit, events := collectEvents()

--- a/client_test.go
+++ b/client_test.go
@@ -1102,3 +1102,339 @@ func TestBrowseSessionTXTUpdate(t *testing.T) {
 		NewTXTString("version", "2"),
 	}, events[1].Instance.Text)
 }
+
+// ---------------------------------------------------------------------------
+// Service removed events (RFC 6762 §10.1 goodbye, TTL expiry)
+// ---------------------------------------------------------------------------
+
+// collectEvents returns an emit callback that records events, plus an
+// accessor returning a snapshot of everything emitted so far.
+func collectEvents() (func(ServiceEvent), func() []ServiceEvent) {
+	var mu sync.Mutex
+	var events []ServiceEvent
+
+	emit := func(evt ServiceEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, evt)
+	}
+	snapshot := func() []ServiceEvent {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return append([]ServiceEvent(nil), events...)
+	}
+
+	return emit, snapshot
+}
+
+// feedInstance drives a browse session through a full PTR → SRV → TXT →
+// A resolution for one "_http._tcp" instance, triggering an emit.
+func feedInstance(t *testing.T, session *browseSession, instance, host, addr string) {
+	t.Helper()
+
+	fqdn := instance + "._http._tcp.local."
+	session.processRecord(mustBuildPTR(t, "_http._tcp.local.", fqdn, 4500), "")
+	session.processRecord(mustBuildSRV(t, fqdn, host, 8080, 120), "")
+	session.processRecord(mustBuildTXT(t, fqdn, []string{"path=/"}, 4500), "")
+	session.processRecord(mustBuildA(t, host, addr, 120), "")
+}
+
+func TestBrowseMonitorsEmittedInstances(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+	require.Len(t, events(), 1)
+
+	// The emitted instance's records must stay monitored so refresh
+	// keeps them alive and their expiry is observed: service PTR + SRV +
+	// TXT for the instance, A + AAAA for the host.
+	keys := session.monitoredCacheKeys()
+	require.Len(t, keys, 5)
+
+	typesByName := make(map[string][]dnsmessage.Type)
+	for _, key := range keys {
+		typesByName[key.name] = append(typesByName[key.name], key.rrType)
+	}
+	assert.ElementsMatch(t,
+		[]dnsmessage.Type{dnsmessage.TypeSRV, dnsmessage.TypeTXT},
+		typesByName["my web._http._tcp.local."])
+	assert.ElementsMatch(t,
+		[]dnsmessage.Type{dnsmessage.TypeA, dnsmessage.TypeAAAA},
+		typesByName["myhost.local."])
+}
+
+func TestBrowsePTRGoodbyeCreatesNoPending(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	// A goodbye PTR (TTL=0) for an unknown instance must not start
+	// resolving it.
+	session.processRecord(mustBuildPTR(t, "_http._tcp.local.", "Ghost._http._tcp.local.", 0), "")
+
+	session.mu.Lock()
+	assert.Empty(t, session.pending)
+	session.mu.Unlock()
+	assert.Empty(t, events())
+}
+
+func TestBrowseExpiredPTREmitsRemoved(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	session.handleExpired(mustBuildPTR(t, "_http._tcp.local.", "My Web._http._tcp.local.", 0))
+
+	evts := events()
+	require.Len(t, evts, 2)
+	assert.Equal(t, ServiceAdded, evts[0].Type)
+
+	removed := evts[1]
+	assert.Equal(t, ServiceRemoved, removed.Type)
+	assert.Equal(t, "My Web", removed.Instance.Instance)
+	assert.Equal(t, "_http._tcp", removed.Instance.Service)
+	assert.Equal(t, "myhost.local.", removed.Instance.Host)
+	assert.Equal(t, uint16(8080), removed.Instance.Port)
+	assert.Equal(t, netip.MustParseAddr("192.168.1.100"), removed.Addr)
+}
+
+func TestBrowseExpiredPTRUnknownInstanceNoEvent(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	session.handleExpired(mustBuildPTR(t, "_http._tcp.local.", "Never Seen._http._tcp.local.", 0))
+
+	evts := events()
+	require.Len(t, evts, 1)
+	assert.Equal(t, ServiceAdded, evts[0].Type)
+}
+
+func TestBrowseExpiredPTRPendingInstanceNoEvent(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	// PTR only: the instance stays pending (no SRV/TXT/A yet).
+	session.processRecord(mustBuildPTR(t, "_http._tcp.local.", "Half Done._http._tcp.local.", 4500), "")
+
+	session.handleExpired(mustBuildPTR(t, "_http._tcp.local.", "Half Done._http._tcp.local.", 0))
+
+	assert.Empty(t, events())
+
+	session.mu.Lock()
+	assert.Empty(t, session.pending)
+	session.mu.Unlock()
+}
+
+func TestBrowseExpiredSRVAloneNoRemoval(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	// SRV (or A) expiry without PTR expiry does not signal removal; the
+	// instance PTR is the canonical presence record.
+	session.handleExpired(mustBuildSRV(t, "My Web._http._tcp.local.", "myhost.local.", 8080, 0))
+	session.handleExpired(mustBuildA(t, "myhost.local.", "192.168.1.100", 0))
+
+	require.Len(t, events(), 1)
+	assert.Len(t, session.monitoredCacheKeys(), 5, "instance should remain monitored")
+}
+
+func TestBrowseCacheFlushReplacementNoRemoval(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	clock := newTestClock()
+	recordCache := newCache(clock.now)
+	handler := newAnswerHandler(log, "test", recordCache)
+
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+	handler.registerBrowseSession(session)
+	defer handler.unregisterBrowseSession(session)
+
+	source := &net.UDPAddr{IP: net.IPv4(192, 168, 1, 1), Port: 5353}
+	handler.handle(&messageContext{source: source, timestamp: clock.now()}, buildBrowseResponseMsg(t))
+	require.Len(t, events(), 1)
+
+	// Two seconds later the service moves ports: a replacement SRV with
+	// the cache-flush bit caps the old SRV entry to 1s (§10.2).
+	clock.advance(2 * time.Second)
+	newSRV := mustBuildSRV(t, "My Web._http._tcp.local.", "myhost.local.", 9090, 120)
+	newSRV.Header.Class |= rrClassCacheFlush
+	handler.handle(&messageContext{source: source, timestamp: clock.now()}, &dnsmessage.Message{
+		Header:  dnsmessage.Header{Response: true},
+		Answers: []dnsmessage.Resource{newSRV},
+	})
+
+	// Sweeping past the cap reports the old SRV as expired. Forwarding
+	// that report must not emit a removal: the instance is alive, only
+	// its rdata changed. The new rdata is reported as ServiceUpdated
+	// (§5.2) because the port moved.
+	clock.advance(1500 * time.Millisecond)
+	expired := recordCache.sweep()
+	require.NotEmpty(t, expired)
+	handler.handleExpired(expired)
+
+	evts := events()
+	require.Len(t, evts, 2)
+	assert.Equal(t, ServiceAdded, evts[0].Type)
+	assert.Equal(t, uint16(8080), evts[0].Instance.Port)
+	assert.Equal(t, ServiceUpdated, evts[1].Type)
+	assert.Equal(t, uint16(9090), evts[1].Instance.Port)
+	for _, evt := range evts {
+		assert.NotEqual(t, ServiceRemoved, evt.Type,
+			"a cache-flush replacement must never be reported as a removal")
+	}
+}
+
+func TestBrowseRediscoveryAfterRemoval(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+	session.handleExpired(mustBuildPTR(t, "_http._tcp.local.", "My Web._http._tcp.local.", 0))
+
+	// The instance comes back: it must be reported as a fresh add.
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	evts := events()
+	require.Len(t, evts, 3)
+	assert.Equal(t, ServiceAdded, evts[0].Type)
+	assert.Equal(t, ServiceRemoved, evts[1].Type)
+	assert.Equal(t, ServiceAdded, evts[2].Type)
+}
+
+func TestBrowseRemovalIdempotent(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	expiredPTR := mustBuildPTR(t, "_http._tcp.local.", "My Web._http._tcp.local.", 0)
+	session.handleExpired(expiredPTR)
+	session.handleExpired(expiredPTR)
+
+	evts := events()
+	require.Len(t, evts, 2, "second expiry of the same instance must not emit again")
+	assert.Equal(t, ServiceRemoved, evts[1].Type)
+}
+
+func TestBrowseRemovalOneOfTwoInstances(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "Alpha", "host-a.local.", "10.0.0.1")
+	feedInstance(t, session, "Beta", "host-b.local.", "10.0.0.2")
+	require.Len(t, events(), 2)
+
+	session.handleExpired(mustBuildPTR(t, "_http._tcp.local.", "Alpha._http._tcp.local.", 0))
+
+	evts := events()
+	require.Len(t, evts, 3)
+	assert.Equal(t, ServiceRemoved, evts[2].Type)
+	assert.Equal(t, "Alpha", evts[2].Instance.Instance)
+
+	// Beta stays active and monitored: PTR + SRV/TXT + A/AAAA.
+	assert.Len(t, session.monitoredCacheKeys(), 5)
+}
+
+func TestBrowseExpiredPTRCaseInsensitive(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	session.handleExpired(mustBuildPTR(t, "_HTTP._tcp.LOCAL.", "MY WEB._HTTP._tcp.LOCAL.", 0))
+
+	evts := events()
+	require.Len(t, evts, 2)
+	assert.Equal(t, ServiceRemoved, evts[1].Type)
+	assert.Equal(t, "My Web", evts[1].Instance.Instance)
+}
+
+func TestBrowseExpiredPTRMalformedIgnored(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	// PTR header with a non-PTR body: rdata parse fails, no event.
+	session.handleExpired(dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{
+			Name:  dnsmessage.MustNewName("_http._tcp.local."),
+			Type:  dnsmessage.TypePTR,
+			Class: dnsmessage.ClassINET,
+		},
+		Body: &dnsmessage.AResource{A: [4]byte{10, 0, 0, 1}},
+	})
+
+	// PTR target that is not a service instance name: parse fails, no event.
+	session.handleExpired(mustBuildPTR(t, "_http._tcp.local.", "local.", 0))
+
+	require.Len(t, events(), 1)
+	assert.Len(t, session.monitoredCacheKeys(), 5, "instance should remain monitored")
+}
+
+func TestBrowseExpiredOtherServiceIgnored(t *testing.T) {
+	emit, events := collectEvents()
+	session := newBrowseSession(t.Context(), "_http._tcp", emit)
+
+	feedInstance(t, session, "My Web", "myhost.local.", "192.168.1.100")
+
+	session.handleExpired(mustBuildPTR(t, "_ipp._tcp.local.", "My Web._ipp._tcp.local.", 0))
+
+	require.Len(t, events(), 1)
+	assert.Len(t, session.monitoredCacheKeys(), 5, "instance should remain monitored")
+}
+
+func TestAnswerHandlerHandleExpiredFanOut(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
+
+	emitHTTP, httpEvents := collectEvents()
+	httpSession := newBrowseSession(t.Context(), "_http._tcp", emitHTTP)
+	handler.registerBrowseSession(httpSession)
+
+	emitIPP, ippEvents := collectEvents()
+	ippSession := newBrowseSession(t.Context(), "_ipp._tcp", emitIPP)
+	handler.registerBrowseSession(ippSession)
+
+	enumSession := newEnumerateSession(t.Context(), func(string) {})
+	handler.registerEnumerateSession(enumSession)
+
+	feedInstance(t, httpSession, "Web", "host-a.local.", "10.0.0.1")
+
+	ippFQDN := "Printer._ipp._tcp.local."
+	ippSession.processRecord(mustBuildPTR(t, "_ipp._tcp.local.", ippFQDN, 4500), "")
+	ippSession.processRecord(mustBuildSRV(t, ippFQDN, "host-b.local.", 631, 120), "")
+	ippSession.processRecord(mustBuildTXT(t, ippFQDN, []string{""}, 4500), "")
+	ippSession.processRecord(mustBuildA(t, "host-b.local.", "10.0.0.2", 120), "")
+
+	handler.handleExpired([]dnsmessage.Resource{
+		mustBuildPTR(t, "_http._tcp.local.", "Web._http._tcp.local.", 0),
+		mustBuildPTR(t, "_ipp._tcp.local.", "Printer._ipp._tcp.local.", 0),
+	})
+
+	httpEvts := httpEvents()
+	require.Len(t, httpEvts, 2)
+	assert.Equal(t, ServiceRemoved, httpEvts[1].Type)
+	assert.Equal(t, "Web", httpEvts[1].Instance.Instance)
+
+	ippEvts := ippEvents()
+	require.Len(t, ippEvts, 2)
+	assert.Equal(t, ServiceRemoved, ippEvts[1].Type)
+	assert.Equal(t, "Printer", ippEvts[1].Instance.Instance)
+}
+
+func TestAnswerHandlerHandleExpiredNoSessions(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
+
+	// No sessions registered: must be a no-op, not a panic.
+	handler.handleExpired([]dnsmessage.Resource{
+		mustBuildPTR(t, "_http._tcp.local.", "My Web._http._tcp.local.", 0),
+	})
+}

--- a/compat_test.go
+++ b/compat_test.go
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+
+package mdns
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/pion/transport/v4/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/dns/dnsmessage"
+	"golang.org/x/net/ipv4"
+)
+
+// These tests pin the backward-compatibility contract of the legacy
+// Server constructor (the options bridge introduced in PR #255).
+// Code written against the pre-options API must keep working unchanged:
+// the legacy constructor opts out of newer behavior that could surprise
+// it. NewServer, by contrast, gets full behavior by default.
+//
+// Legacy defaults pinned here:
+//   - only A/AAAA records are processed (WebRTC/ICE focus)
+//   - no proactive cache refresh (RFC 6762 §5.2)
+//   - only ServiceAdded events are delivered (no ServiceRemoved)
+
+func newLegacyServer(t *testing.T, cfg *Config) *Conn {
+	t.Helper()
+
+	sock := createListener4(t)
+	conn, err := Server(ipv4.NewPacketConn(sock), nil, cfg)
+	require.NoError(t, err)
+
+	return conn
+}
+
+func TestLegacyServerDefaults(t *testing.T) {
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	conn := newLegacyServer(t, &Config{})
+
+	assert.Equal(t,
+		[]dnsmessage.Type{dnsmessage.TypeA, dnsmessage.TypeAAAA},
+		conn.server.handler.allowedRecordTypes,
+		"legacy Server must only process A/AAAA records")
+	assert.False(t, conn.cacheRefresh,
+		"legacy Server must not enable proactive cache refresh")
+	assert.Equal(t, []ServiceEventType{ServiceAdded}, conn.serviceEventTypes,
+		"legacy Server must only deliver ServiceAdded events")
+
+	assert.NoError(t, conn.Close())
+}
+
+func TestLegacyServerFiltersServiceRemoved(t *testing.T) {
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	conn := newLegacyServer(t, &Config{})
+
+	var received []ServiceEvent
+	conn.OnServiceDiscovered(func(evt ServiceEvent) {
+		received = append(received, evt)
+	})
+
+	added := ServiceEvent{
+		Type: ServiceAdded,
+		Instance: ServiceInstance{
+			Instance: "My Web", Service: "_http._tcp", Domain: "local",
+			Host: "myhost.local.", Port: 8080,
+		},
+		Addr: netip.MustParseAddr("192.168.1.100"),
+	}
+	removed := added
+	removed.Type = ServiceRemoved
+
+	conn.serviceEventHandler(added)
+	conn.serviceEventHandler(removed)
+
+	// Pre-removal-events code only ever saw discoveries; the legacy
+	// constructor preserves that: the removal is silently dropped.
+	require.Len(t, received, 1)
+	assert.Equal(t, ServiceAdded, received[0].Type)
+
+	assert.NoError(t, conn.Close())
+}
+
+func TestNewServerDeliversAllServiceEvents(t *testing.T) {
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	sock := createListener4(t)
+	conn, err := NewServer(ipv4.NewPacketConn(sock), nil)
+	require.NoError(t, err)
+
+	var received []ServiceEvent
+	conn.OnServiceEvent(func(evt ServiceEvent) {
+		received = append(received, evt)
+	})
+
+	conn.serviceEventHandler(ServiceEvent{Type: ServiceAdded})
+	conn.serviceEventHandler(ServiceEvent{Type: ServiceRemoved})
+
+	require.Len(t, received, 2)
+	assert.Equal(t, ServiceAdded, received[0].Type)
+	assert.Equal(t, ServiceRemoved, received[1].Type)
+
+	assert.NoError(t, conn.Close())
+}
+
+func TestNewServerWithServiceEventTypesOptIn(t *testing.T) {
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	// NewServer users can opt into the legacy adds-only behavior.
+	sock := createListener4(t)
+	conn, err := NewServer(ipv4.NewPacketConn(sock), nil,
+		WithServiceEventTypes(ServiceAdded))
+	require.NoError(t, err)
+
+	var received []ServiceEvent
+	conn.OnServiceEvent(func(evt ServiceEvent) {
+		received = append(received, evt)
+	})
+
+	conn.serviceEventHandler(ServiceEvent{Type: ServiceAdded})
+	conn.serviceEventHandler(ServiceEvent{Type: ServiceRemoved})
+
+	require.Len(t, received, 1)
+	assert.Equal(t, ServiceAdded, received[0].Type)
+
+	assert.NoError(t, conn.Close())
+}
+
+func TestLegacyServerConfigMapping(t *testing.T) {
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	conn := newLegacyServer(t, &Config{
+		Name:          "legacy-name",
+		QueryInterval: 250 * time.Millisecond,
+		LocalNames:    []string{"legacy-host.local"},
+		LocalAddress:  net.ParseIP("192.0.2.10"),
+	})
+
+	assert.Equal(t, "legacy-name", conn.name)
+	assert.Equal(t, 250*time.Millisecond, conn.queryInterval)
+	assert.Equal(t, []string{"legacy-host.local."}, conn.localNames,
+		"local names should be normalized with a trailing dot")
+
+	assert.NoError(t, conn.Close())
+}

--- a/compat_test.go
+++ b/compat_test.go
@@ -60,19 +60,15 @@ func TestLegacyServerDefaults(t *testing.T) {
 	assert.NoError(t, conn.Close())
 }
 
-func TestLegacyServerFiltersServiceRemoved(t *testing.T) {
+// The legacy constructor delivers only ServiceAdded: pre-existing handlers
+// were written when a discovery was the only kind of event, so neither
+// ServiceUpdated (DNS-SD TXT updates) nor ServiceRemoved reaches them.
+func TestLegacyServerFiltersNonAddedEvents(t *testing.T) {
 	lim := test.TimeOut(time.Second * 10)
 	defer lim.Stop()
 
 	report := test.CheckRoutines(t)
 	defer report()
-
-	conn := newLegacyServer(t, &Config{})
-
-	var received []ServiceEvent
-	conn.OnServiceDiscovered(func(evt ServiceEvent) {
-		received = append(received, evt)
-	})
 
 	added := ServiceEvent{
 		Type: ServiceAdded,
@@ -82,18 +78,26 @@ func TestLegacyServerFiltersServiceRemoved(t *testing.T) {
 		},
 		Addr: netip.MustParseAddr("192.168.1.100"),
 	}
-	removed := added
-	removed.Type = ServiceRemoved
 
-	conn.serviceEventHandler(added)
-	conn.serviceEventHandler(removed)
+	for _, filtered := range []ServiceEventType{ServiceUpdated, ServiceRemoved} {
+		conn := newLegacyServer(t, &Config{})
 
-	// Pre-removal-events code only ever saw discoveries; the legacy
-	// constructor preserves that: the removal is silently dropped.
-	require.Len(t, received, 1)
-	assert.Equal(t, ServiceAdded, received[0].Type)
+		var received []ServiceEvent
+		conn.OnServiceDiscovered(func(evt ServiceEvent) {
+			received = append(received, evt)
+		})
 
-	assert.NoError(t, conn.Close())
+		dropped := added
+		dropped.Type = filtered
+
+		conn.serviceEventHandler(added)
+		conn.serviceEventHandler(dropped)
+
+		require.Len(t, received, 1, "event type %d must be dropped", filtered)
+		assert.Equal(t, ServiceAdded, received[0].Type)
+
+		assert.NoError(t, conn.Close())
+	}
 }
 
 func TestNewServerDeliversAllServiceEvents(t *testing.T) {

--- a/config.go
+++ b/config.go
@@ -212,6 +212,27 @@ func (o recordTypesOption) applyServer(c *serverConfig) error {
 	return nil
 }
 
+// serviceEventTypesOption limits which service event types are delivered.
+type serviceEventTypesOption []ServiceEventType
+
+// WithServiceEventTypes limits which ServiceEvent types Browse delivers
+// to the OnServiceEvent handler. By default (if not called), all event
+// types are delivered.
+//
+// The legacy Server constructor restricts delivery to ServiceAdded so
+// that code written before removal events existed never sees them:
+//
+//	mdns.WithServiceEventTypes(mdns.ServiceAdded)
+func WithServiceEventTypes(types ...ServiceEventType) serviceEventTypesOption {
+	return serviceEventTypesOption(types)
+}
+
+func (o serviceEventTypesOption) applyServer(c *serverConfig) error {
+	c.serviceEventTypes = []ServiceEventType(o)
+
+	return nil
+}
+
 // serviceOption registers a DNS-SD service instance to advertise.
 type serviceOption struct {
 	svc ServiceInstance

--- a/config.go
+++ b/config.go
@@ -220,7 +220,8 @@ type serviceEventTypesOption []ServiceEventType
 // types are delivered.
 //
 // The legacy Server constructor restricts delivery to ServiceAdded so
-// that code written before removal events existed never sees them:
+// that code written before update and removal events existed never sees
+// them:
 //
 //	mdns.WithServiceEventTypes(mdns.ServiceAdded)
 func WithServiceEventTypes(types ...ServiceEventType) serviceEventTypesOption {

--- a/conn.go
+++ b/conn.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -55,8 +56,12 @@ type Conn struct {
 	// sweepInterval overrides the default cache sweep interval.
 	sweepInterval time.Duration
 
-	// onServiceDiscovered is the handler for Browse results.
-	onServiceDiscovered atomic.Value // func(ServiceEvent)
+	// onServiceEvent is the handler for Browse lifecycle events.
+	onServiceEvent atomic.Value // func(ServiceEvent)
+
+	// serviceEventTypes limits which ServiceEvent types are delivered to
+	// the handler. Empty means all types. Set at construction, immutable.
+	serviceEventTypes []ServiceEventType
 
 	// onServiceTypeDiscovered is the handler for EnumerateServiceTypes results.
 	onServiceTypeDiscovered atomic.Value // func(string)
@@ -196,18 +201,44 @@ func (c *Conn) Unregister(instance, service string) {
 	c.server.unregisterService(instance, service)
 }
 
-// OnServiceDiscovered sets a handler that is fired when a DNS-SD service
-// instance is discovered during browsing. The handler is stored atomically
-// and may be changed at any time. Set to nil to clear.
-func (c *Conn) OnServiceDiscovered(handler func(ServiceEvent)) {
-	c.onServiceDiscovered.Store(handler)
+// OnServiceEvent sets a handler that is fired for DNS-SD service
+// lifecycle events observed while browsing: ServiceAdded when an
+// instance has been fully resolved, ServiceRemoved when a previously
+// reported instance leaves the network (goodbye packet) or its records
+// expire. The handler is stored atomically and may be changed at any
+// time; it may be invoked from internal goroutines. Set to nil to clear.
+func (c *Conn) OnServiceEvent(handler func(ServiceEvent)) {
+	c.onServiceEvent.Store(handler)
 }
 
-// serviceDiscoveredHandler dispatches a ServiceEvent to the registered handler.
-func (c *Conn) serviceDiscoveredHandler(evt ServiceEvent) {
-	if handler, ok := c.onServiceDiscovered.Load().(func(ServiceEvent)); ok && handler != nil {
+// OnServiceDiscovered sets a handler that is fired when a DNS-SD service
+// instance is discovered during browsing.
+//
+// Deprecated: use OnServiceEvent. On connections built with NewServer,
+// handlers registered here also receive ServiceRemoved events; check
+// ServiceEvent.Type. Connections built with the legacy Server
+// constructor deliver only ServiceAdded events (see
+// WithServiceEventTypes).
+func (c *Conn) OnServiceDiscovered(handler func(ServiceEvent)) {
+	c.OnServiceEvent(handler)
+}
+
+// serviceEventHandler dispatches a ServiceEvent to the registered
+// handler, applying the configured event type filter.
+func (c *Conn) serviceEventHandler(evt ServiceEvent) {
+	if !c.deliversServiceEvent(evt.Type) {
+		return
+	}
+
+	if handler, ok := c.onServiceEvent.Load().(func(ServiceEvent)); ok && handler != nil {
 		handler(evt)
 	}
+}
+
+// deliversServiceEvent reports whether the configured filter allows the
+// given event type. An empty filter allows all types.
+func (c *Conn) deliversServiceEvent(eventType ServiceEventType) bool {
+	return len(c.serviceEventTypes) == 0 || slices.Contains(c.serviceEventTypes, eventType)
 }
 
 // OnServiceTypeDiscovered sets a handler that is fired when a service type
@@ -226,17 +257,24 @@ func (c *Conn) serviceTypeDiscoveredHandler(serviceType string) {
 
 // Browse starts discovering DNS-SD service instances of the given type on
 // the local network. It sends periodic PTR queries for
-// "<serviceType>.local." and fires the OnServiceDiscovered handler for each
-// unique instance found.
+// "<serviceType>.local." and fires the OnServiceEvent handler with a
+// ServiceAdded event for each unique instance found, and a
+// ServiceRemoved event when a previously reported instance leaves.
 //
 // The context controls the lifetime of the browse operation.
-// Discovered instances are deduplicated.
+// Discovered instances are deduplicated; after a removal the same
+// instance is reported again if it reappears.
 //
 // Example:
 //
-//	conn.OnServiceDiscovered(func(evt mdns.ServiceEvent) {
-//	    fmt.Printf("Found: %s at %s:%d\n",
-//	        evt.Instance.Instance, evt.Addr, evt.Instance.Port)
+//	conn.OnServiceEvent(func(evt mdns.ServiceEvent) {
+//	    switch evt.Type {
+//	    case mdns.ServiceAdded:
+//	        fmt.Printf("Found: %s at %s:%d\n",
+//	            evt.Instance.Instance, evt.Addr, evt.Instance.Port)
+//	    case mdns.ServiceRemoved:
+//	        fmt.Printf("Gone: %s\n", evt.Instance.Instance)
+//	    }
 //	})
 //	err := conn.Browse(ctx, "_http._tcp")
 func (c *Conn) Browse(ctx context.Context, serviceType string) error {
@@ -254,7 +292,7 @@ func (c *Conn) Browse(ctx context.Context, serviceType string) error {
 		return err
 	}
 
-	session := newBrowseSession(ctx, serviceType, c.serviceDiscoveredHandler)
+	session := newBrowseSession(ctx, serviceType, c.serviceEventHandler)
 
 	c.client.handler.registerBrowseSession(session)
 
@@ -676,7 +714,9 @@ func (c *Conn) startBackgroundLoops() *sync.WaitGroup {
 	return &backgroundWG
 }
 
-// sweepLoop periodically removes expired cache entries.
+// sweepLoop periodically removes expired cache entries and forwards
+// them to the client handler, which drives ServiceRemoved events for
+// browsed instances whose records expired (goodbye or unrefreshed TTL).
 func (c *Conn) sweepLoop() {
 	interval := c.sweepInterval
 	if interval == 0 {
@@ -689,7 +729,9 @@ func (c *Conn) sweepLoop() {
 	for {
 		select {
 		case <-ticker.C:
-			c.cache.sweep()
+			if expired := c.cache.sweep(); len(expired) > 0 && c.client != nil {
+				c.client.handler.handleExpired(expired)
+			}
 		case <-c.stopBackground:
 			return
 		}

--- a/conn.go
+++ b/conn.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -55,8 +56,12 @@ type Conn struct {
 	// sweepInterval overrides the default cache sweep interval.
 	sweepInterval time.Duration
 
-	// onServiceDiscovered is the handler for Browse results.
-	onServiceDiscovered atomic.Value // func(ServiceEvent)
+	// onServiceEvent is the handler for Browse lifecycle events.
+	onServiceEvent atomic.Value // func(ServiceEvent)
+
+	// serviceEventTypes limits which ServiceEvent types are delivered to
+	// the handler. Empty means all types. Set at construction, immutable.
+	serviceEventTypes []ServiceEventType
 
 	// onServiceTypeDiscovered is the handler for EnumerateServiceTypes results.
 	onServiceTypeDiscovered atomic.Value // func(string)
@@ -246,18 +251,44 @@ func (c *Conn) Unregister(instance, service string) {
 	c.server.unregisterService(instance, service)
 }
 
-// OnServiceDiscovered sets a handler that is fired when a DNS-SD service
-// instance is discovered during browsing. The handler is stored atomically
-// and may be changed at any time. Set to nil to clear.
-func (c *Conn) OnServiceDiscovered(handler func(ServiceEvent)) {
-	c.onServiceDiscovered.Store(handler)
+// OnServiceEvent sets a handler that is fired for DNS-SD service
+// lifecycle events observed while browsing: ServiceAdded when an
+// instance has been fully resolved, ServiceRemoved when a previously
+// reported instance leaves the network (goodbye packet) or its records
+// expire. The handler is stored atomically and may be changed at any
+// time; it may be invoked from internal goroutines. Set to nil to clear.
+func (c *Conn) OnServiceEvent(handler func(ServiceEvent)) {
+	c.onServiceEvent.Store(handler)
 }
 
-// serviceDiscoveredHandler dispatches a ServiceEvent to the registered handler.
-func (c *Conn) serviceDiscoveredHandler(evt ServiceEvent) {
-	if handler, ok := c.onServiceDiscovered.Load().(func(ServiceEvent)); ok && handler != nil {
+// OnServiceDiscovered sets a handler that is fired when a DNS-SD service
+// instance is discovered during browsing.
+//
+// Deprecated: use OnServiceEvent. On connections built with NewServer,
+// handlers registered here also receive ServiceRemoved events; check
+// ServiceEvent.Type. Connections built with the legacy Server
+// constructor deliver only ServiceAdded events (see
+// WithServiceEventTypes).
+func (c *Conn) OnServiceDiscovered(handler func(ServiceEvent)) {
+	c.OnServiceEvent(handler)
+}
+
+// serviceEventHandler dispatches a ServiceEvent to the registered
+// handler, applying the configured event type filter.
+func (c *Conn) serviceEventHandler(evt ServiceEvent) {
+	if !c.deliversServiceEvent(evt.Type) {
+		return
+	}
+
+	if handler, ok := c.onServiceEvent.Load().(func(ServiceEvent)); ok && handler != nil {
 		handler(evt)
 	}
+}
+
+// deliversServiceEvent reports whether the configured filter allows the
+// given event type. An empty filter allows all types.
+func (c *Conn) deliversServiceEvent(eventType ServiceEventType) bool {
+	return len(c.serviceEventTypes) == 0 || slices.Contains(c.serviceEventTypes, eventType)
 }
 
 // OnServiceTypeDiscovered sets a handler that is fired when a service type
@@ -276,17 +307,24 @@ func (c *Conn) serviceTypeDiscoveredHandler(serviceType string) {
 
 // Browse starts discovering DNS-SD service instances of the given type on
 // the local network. It sends periodic PTR queries for
-// "<serviceType>.local." and fires the OnServiceDiscovered handler for each
-// unique instance found.
+// "<serviceType>.local." and fires the OnServiceEvent handler with a
+// ServiceAdded event for each unique instance found, and a
+// ServiceRemoved event when a previously reported instance leaves.
 //
 // The context controls the lifetime of the browse operation.
-// Discovered instances are deduplicated.
+// Discovered instances are deduplicated; after a removal the same
+// instance is reported again if it reappears.
 //
 // Example:
 //
-//	conn.OnServiceDiscovered(func(evt mdns.ServiceEvent) {
-//	    fmt.Printf("Found: %s at %s:%d\n",
-//	        evt.Instance.Instance, evt.Addr, evt.Instance.Port)
+//	conn.OnServiceEvent(func(evt mdns.ServiceEvent) {
+//	    switch evt.Type {
+//	    case mdns.ServiceAdded:
+//	        fmt.Printf("Found: %s at %s:%d\n",
+//	            evt.Instance.Instance, evt.Addr, evt.Instance.Port)
+//	    case mdns.ServiceRemoved:
+//	        fmt.Printf("Gone: %s\n", evt.Instance.Instance)
+//	    }
 //	})
 //	err := conn.Browse(ctx, "_http._tcp")
 func (c *Conn) Browse(ctx context.Context, serviceType string) error {
@@ -304,7 +342,7 @@ func (c *Conn) Browse(ctx context.Context, serviceType string) error {
 		return err
 	}
 
-	session := newBrowseSession(ctx, serviceType, c.serviceDiscoveredHandler)
+	session := newBrowseSession(ctx, serviceType, c.serviceEventHandler)
 
 	c.client.handler.registerBrowseSession(session)
 
@@ -726,7 +764,9 @@ func (c *Conn) startBackgroundLoops() *sync.WaitGroup {
 	return &backgroundWG
 }
 
-// sweepLoop periodically removes expired cache entries.
+// sweepLoop periodically removes expired cache entries and forwards
+// them to the client handler, which drives ServiceRemoved events for
+// browsed instances whose records expired (goodbye or unrefreshed TTL).
 func (c *Conn) sweepLoop() {
 	interval := c.sweepInterval
 	if interval == 0 {
@@ -739,7 +779,9 @@ func (c *Conn) sweepLoop() {
 	for {
 		select {
 		case <-ticker.C:
-			c.cache.sweep()
+			if expired := c.cache.sweep(); len(expired) > 0 && c.client != nil {
+				c.client.handler.handleExpired(expired)
+			}
 		case <-c.stopBackground:
 			return
 		}

--- a/conn.go
+++ b/conn.go
@@ -265,9 +265,9 @@ func (c *Conn) OnServiceEvent(handler func(ServiceEvent)) {
 // instance is discovered during browsing.
 //
 // Deprecated: use OnServiceEvent. On connections built with NewServer,
-// handlers registered here also receive ServiceRemoved events; check
-// ServiceEvent.Type. Connections built with the legacy Server
-// constructor deliver only ServiceAdded events (see
+// handlers registered here also receive ServiceUpdated and
+// ServiceRemoved events; check ServiceEvent.Type. Connections built with
+// the legacy Server constructor deliver only ServiceAdded events (see
 // WithServiceEventTypes).
 func (c *Conn) OnServiceDiscovered(handler func(ServiceEvent)) {
 	c.OnServiceEvent(handler)

--- a/conn_test.go
+++ b/conn_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/transport/v4/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/dns/dnsmessage"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
@@ -1471,6 +1472,221 @@ func TestDynamicRegisterAndBrowse(t *testing.T) {
 	cancel()
 	assert.NoError(t, aServer.Close())
 	assert.NoError(t, bServer.Close())
+}
+
+// newFakeBrowseConn builds a started Conn wired to a fakePkt so tests
+// can inject packets into the read loop without real sockets.
+func newFakeBrowseConn(t *testing.T, sweepInterval time.Duration) (*Conn, *fakePkt) {
+	t.Helper()
+
+	fp := &fakePkt{in: make(chan struct{}, 1), close: make(chan struct{})}
+	fp.src = &net.UDPAddr{IP: net.IPv4(192, 0, 2, 1), Port: 5353}
+
+	log := logging.NewDefaultLoggerFactory().NewLogger("mdns")
+	conn := &Conn{
+		name:               "test",
+		log:                log,
+		queryInterval:      100 * time.Millisecond,
+		multicastPktConnV4: fp,
+		dstAddr4:           &net.UDPAddr{IP: net.IPv4(224, 0, 0, 251), Port: 5353},
+		ifaces: map[int]netInterface{
+			1: {
+				Interface:  net.Interface{Index: 1, Flags: net.FlagMulticast | net.FlagUp},
+				supportsV4: true,
+			},
+		},
+		cache:          newCache(time.Now),
+		closed:         make(chan any),
+		stopBackground: make(chan struct{}),
+		sweepInterval:  sweepInterval,
+	}
+	conn.client = newClient(log, "test", conn, true, false, conn.cache)
+
+	started := make(chan struct{})
+	go conn.start(started, 1500, &serverConfig{localAddress: net.ParseIP("127.0.0.1")})
+	<-started
+
+	return conn, fp
+}
+
+// injectPacket delivers a packed DNS message to the conn's read loop
+// through the fake packet conn.
+func injectPacket(t *testing.T, fp *fakePkt, msg *dnsmessage.Message) {
+	t.Helper()
+
+	packed, err := msg.Pack()
+	require.NoError(t, err)
+
+	fp.data = packed
+	fp.in <- struct{}{}
+}
+
+// browseResponseMsg builds a full DNS-SD response (PTR + SRV + TXT + A)
+// for one "_http._tcp" instance with the given TTL on every record.
+func browseResponseMsg(t *testing.T, instance string, ttl uint32) *dnsmessage.Message {
+	t.Helper()
+
+	fqdn := instance + "._http._tcp.local."
+
+	return &dnsmessage.Message{
+		Header: dnsmessage.Header{Response: true, Authoritative: true},
+		Answers: []dnsmessage.Resource{
+			mustBuildPTR(t, "_http._tcp.local.", fqdn, ttl),
+			mustBuildSRV(t, fqdn, "myhost.local.", 8080, ttl),
+			mustBuildTXT(t, fqdn, []string{"path=/"}, ttl),
+			mustBuildA(t, "myhost.local.", "192.168.1.100", ttl),
+		},
+	}
+}
+
+// waitForEvent receives one ServiceEvent or fails the test.
+func waitForEvent(t *testing.T, events <-chan ServiceEvent, timeout time.Duration) ServiceEvent {
+	t.Helper()
+
+	select {
+	case evt := <-events:
+		return evt
+	case <-time.After(timeout):
+		require.Fail(t, "timed out waiting for service event")
+
+		return ServiceEvent{}
+	}
+}
+
+func TestBrowseServiceRemovedOnGoodbye(t *testing.T) {
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	conn, fp := newFakeBrowseConn(t, 50*time.Millisecond)
+
+	events := make(chan ServiceEvent, 8)
+	conn.OnServiceEvent(func(evt ServiceEvent) {
+		if evt.Instance.Instance == "Goodbye Me" {
+			events <- evt
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, conn.Browse(ctx, "_http._tcp"))
+
+	injectPacket(t, fp, browseResponseMsg(t, "Goodbye Me", 4500))
+
+	evt := waitForEvent(t, events, 3*time.Second)
+	assert.Equal(t, ServiceAdded, evt.Type)
+
+	// The responder leaves: goodbye PTR with TTL=0 (RFC 6762 §10.1).
+	// The cache retains it for 1s, then the sweep loop collects it and
+	// the removal event fires.
+	injectPacket(t, fp, &dnsmessage.Message{
+		Header: dnsmessage.Header{Response: true, Authoritative: true},
+		Answers: []dnsmessage.Resource{
+			mustBuildPTR(t, "_http._tcp.local.", "Goodbye Me._http._tcp.local.", 0),
+		},
+	})
+
+	evt = waitForEvent(t, events, 5*time.Second)
+	assert.Equal(t, ServiceRemoved, evt.Type)
+	assert.Equal(t, "Goodbye Me", evt.Instance.Instance)
+	assert.Equal(t, uint16(8080), evt.Instance.Port)
+	assert.Equal(t, netip.MustParseAddr("192.168.1.100"), evt.Addr)
+
+	cancel()
+	assert.NoError(t, conn.Close())
+}
+
+func TestBrowseServiceRemovedOnExpiry(t *testing.T) {
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	conn, fp := newFakeBrowseConn(t, 50*time.Millisecond)
+
+	events := make(chan ServiceEvent, 8)
+	conn.OnServiceEvent(func(evt ServiceEvent) {
+		if evt.Instance.Instance == "Expire Me" {
+			events <- evt
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, conn.Browse(ctx, "_http._tcp"))
+
+	// 1s TTL and a responder that goes silent: no refresh answers, so
+	// the records expire and the sweep drives the removal.
+	injectPacket(t, fp, browseResponseMsg(t, "Expire Me", 1))
+
+	evt := waitForEvent(t, events, 3*time.Second)
+	assert.Equal(t, ServiceAdded, evt.Type)
+
+	evt = waitForEvent(t, events, 5*time.Second)
+	assert.Equal(t, ServiceRemoved, evt.Type)
+	assert.Equal(t, "Expire Me", evt.Instance.Instance)
+
+	cancel()
+	assert.NoError(t, conn.Close())
+}
+
+func TestBrowseRemovedEventGoroutineSafety(t *testing.T) {
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	conn := &Conn{}
+	conn.OnServiceEvent(func(ServiceEvent) {})
+
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	session := newBrowseSession(ctx, "_http._tcp", conn.serviceEventHandler)
+	handler.registerBrowseSession(session)
+
+	// Pre-built on the main goroutine; mustBuild* may FailNow.
+	fqdn := "Race Me._http._tcp.local."
+	ptr := mustBuildPTR(t, "_http._tcp.local.", fqdn, 4500)
+	srv := mustBuildSRV(t, fqdn, "myhost.local.", 8080, 120)
+	txt := mustBuildTXT(t, fqdn, []string{""}, 4500)
+	aRec := mustBuildA(t, "myhost.local.", "10.0.0.1", 120)
+	gone := mustBuildPTR(t, "_http._tcp.local.", fqdn, 0)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Handlers are swapped while add/remove events are being emitted;
+	// the race detector validates the atomic handler storage.
+	go func() {
+		defer wg.Done()
+
+		for range 200 {
+			conn.OnServiceEvent(func(ServiceEvent) {})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for range 200 {
+			session.processRecord(ptr, "")
+			session.processRecord(srv, "")
+			session.processRecord(txt, "")
+			session.processRecord(aRec, "")
+			handler.handleExpired([]dnsmessage.Resource{gone})
+		}
+	}()
+
+	wg.Wait()
+	cancel()
 }
 
 func TestIPToBytes(t *testing.T) { //nolint:cyclop

--- a/conn_test.go
+++ b/conn_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/transport/v4/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/dns/dnsmessage"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
@@ -1473,6 +1474,221 @@ func TestDynamicRegisterAndBrowse(t *testing.T) {
 	cancel()
 	assert.NoError(t, aServer.Close())
 	assert.NoError(t, bServer.Close())
+}
+
+// newFakeBrowseConn builds a started Conn wired to a fakePkt so tests
+// can inject packets into the read loop without real sockets.
+func newFakeBrowseConn(t *testing.T, sweepInterval time.Duration) (*Conn, *fakePkt) {
+	t.Helper()
+
+	fp := &fakePkt{in: make(chan struct{}, 1), close: make(chan struct{})}
+	fp.src = &net.UDPAddr{IP: net.IPv4(192, 0, 2, 1), Port: 5353}
+
+	log := logging.NewDefaultLoggerFactory().NewLogger("mdns")
+	conn := &Conn{
+		name:               "test",
+		log:                log,
+		queryInterval:      100 * time.Millisecond,
+		multicastPktConnV4: fp,
+		dstAddr4:           &net.UDPAddr{IP: net.IPv4(224, 0, 0, 251), Port: 5353},
+		ifaces: map[int]netInterface{
+			1: {
+				Interface:  net.Interface{Index: 1, Flags: net.FlagMulticast | net.FlagUp},
+				supportsV4: true,
+			},
+		},
+		cache:          newCache(time.Now),
+		closed:         make(chan any),
+		stopBackground: make(chan struct{}),
+		sweepInterval:  sweepInterval,
+	}
+	conn.client = newClient(log, "test", conn, true, false, conn.cache)
+
+	started := make(chan struct{})
+	go conn.start(started, 1500, &serverConfig{localAddress: net.ParseIP("127.0.0.1")})
+	<-started
+
+	return conn, fp
+}
+
+// injectPacket delivers a packed DNS message to the conn's read loop
+// through the fake packet conn.
+func injectPacket(t *testing.T, fp *fakePkt, msg *dnsmessage.Message) {
+	t.Helper()
+
+	packed, err := msg.Pack()
+	require.NoError(t, err)
+
+	fp.data = packed
+	fp.in <- struct{}{}
+}
+
+// browseResponseMsg builds a full DNS-SD response (PTR + SRV + TXT + A)
+// for one "_http._tcp" instance with the given TTL on every record.
+func browseResponseMsg(t *testing.T, instance string, ttl uint32) *dnsmessage.Message {
+	t.Helper()
+
+	fqdn := instance + "._http._tcp.local."
+
+	return &dnsmessage.Message{
+		Header: dnsmessage.Header{Response: true, Authoritative: true},
+		Answers: []dnsmessage.Resource{
+			mustBuildPTR(t, "_http._tcp.local.", fqdn, ttl),
+			mustBuildSRV(t, fqdn, "myhost.local.", 8080, ttl),
+			mustBuildTXT(t, fqdn, []string{"path=/"}, ttl),
+			mustBuildA(t, "myhost.local.", "192.168.1.100", ttl),
+		},
+	}
+}
+
+// waitForEvent receives one ServiceEvent or fails the test.
+func waitForEvent(t *testing.T, events <-chan ServiceEvent, timeout time.Duration) ServiceEvent {
+	t.Helper()
+
+	select {
+	case evt := <-events:
+		return evt
+	case <-time.After(timeout):
+		require.Fail(t, "timed out waiting for service event")
+
+		return ServiceEvent{}
+	}
+}
+
+func TestBrowseServiceRemovedOnGoodbye(t *testing.T) {
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	conn, fp := newFakeBrowseConn(t, 50*time.Millisecond)
+
+	events := make(chan ServiceEvent, 8)
+	conn.OnServiceEvent(func(evt ServiceEvent) {
+		if evt.Instance.Instance == "Goodbye Me" {
+			events <- evt
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, conn.Browse(ctx, "_http._tcp"))
+
+	injectPacket(t, fp, browseResponseMsg(t, "Goodbye Me", 4500))
+
+	evt := waitForEvent(t, events, 3*time.Second)
+	assert.Equal(t, ServiceAdded, evt.Type)
+
+	// The responder leaves: goodbye PTR with TTL=0 (RFC 6762 §10.1).
+	// The cache retains it for 1s, then the sweep loop collects it and
+	// the removal event fires.
+	injectPacket(t, fp, &dnsmessage.Message{
+		Header: dnsmessage.Header{Response: true, Authoritative: true},
+		Answers: []dnsmessage.Resource{
+			mustBuildPTR(t, "_http._tcp.local.", "Goodbye Me._http._tcp.local.", 0),
+		},
+	})
+
+	evt = waitForEvent(t, events, 5*time.Second)
+	assert.Equal(t, ServiceRemoved, evt.Type)
+	assert.Equal(t, "Goodbye Me", evt.Instance.Instance)
+	assert.Equal(t, uint16(8080), evt.Instance.Port)
+	assert.Equal(t, netip.MustParseAddr("192.168.1.100"), evt.Addr)
+
+	cancel()
+	assert.NoError(t, conn.Close())
+}
+
+func TestBrowseServiceRemovedOnExpiry(t *testing.T) {
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	conn, fp := newFakeBrowseConn(t, 50*time.Millisecond)
+
+	events := make(chan ServiceEvent, 8)
+	conn.OnServiceEvent(func(evt ServiceEvent) {
+		if evt.Instance.Instance == "Expire Me" {
+			events <- evt
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, conn.Browse(ctx, "_http._tcp"))
+
+	// 1s TTL and a responder that goes silent: no refresh answers, so
+	// the records expire and the sweep drives the removal.
+	injectPacket(t, fp, browseResponseMsg(t, "Expire Me", 1))
+
+	evt := waitForEvent(t, events, 3*time.Second)
+	assert.Equal(t, ServiceAdded, evt.Type)
+
+	evt = waitForEvent(t, events, 5*time.Second)
+	assert.Equal(t, ServiceRemoved, evt.Type)
+	assert.Equal(t, "Expire Me", evt.Instance.Instance)
+
+	cancel()
+	assert.NoError(t, conn.Close())
+}
+
+func TestBrowseRemovedEventGoroutineSafety(t *testing.T) {
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	conn := &Conn{}
+	conn.OnServiceEvent(func(ServiceEvent) {})
+
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	session := newBrowseSession(ctx, "_http._tcp", conn.serviceEventHandler)
+	handler.registerBrowseSession(session)
+
+	// Pre-built on the main goroutine; mustBuild* may FailNow.
+	fqdn := "Race Me._http._tcp.local."
+	ptr := mustBuildPTR(t, "_http._tcp.local.", fqdn, 4500)
+	srv := mustBuildSRV(t, fqdn, "myhost.local.", 8080, 120)
+	txt := mustBuildTXT(t, fqdn, []string{""}, 4500)
+	aRec := mustBuildA(t, "myhost.local.", "10.0.0.1", 120)
+	gone := mustBuildPTR(t, "_http._tcp.local.", fqdn, 0)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Handlers are swapped while add/remove events are being emitted;
+	// the race detector validates the atomic handler storage.
+	go func() {
+		defer wg.Done()
+
+		for range 200 {
+			conn.OnServiceEvent(func(ServiceEvent) {})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for range 200 {
+			session.processRecord(ptr, "")
+			session.processRecord(srv, "")
+			session.processRecord(txt, "")
+			session.processRecord(aRec, "")
+			handler.handleExpired([]dnsmessage.Resource{gone})
+		}
+	}()
+
+	wg.Wait()
+	cancel()
 }
 
 func TestIPToBytes(t *testing.T) { //nolint:cyclop

--- a/dns_sd.go
+++ b/dns_sd.go
@@ -28,14 +28,34 @@ var (
 	errUnhandledServiceQuestionType = errors.New("mDNS: unhandled DNS-SD question type")
 )
 
-// ServiceEvent represents a discovered DNS-SD service instance.
-// It is emitted by Browse when a complete service instance has been resolved
-// (PTR → SRV + TXT → address).
+// ServiceEventType distinguishes DNS-SD service lifecycle events.
+type ServiceEventType int
+
+const (
+	// ServiceAdded indicates a newly discovered service instance.
+	ServiceAdded ServiceEventType = iota
+
+	// ServiceRemoved indicates a previously discovered instance is gone:
+	// its PTR record was withdrawn with a goodbye packet (RFC 6762 §10.1)
+	// or expired without being refreshed.
+	ServiceRemoved
+)
+
+// ServiceEvent represents a DNS-SD service lifecycle event observed
+// while browsing. A ServiceAdded event is emitted when a complete
+// service instance has been resolved (PTR → SRV + TXT → address); a
+// ServiceRemoved event when a previously reported instance leaves the
+// network.
 type ServiceEvent struct {
-	// Instance is the discovered service.
+	// Type is the kind of event. The zero value is ServiceAdded.
+	Type ServiceEventType
+
+	// Instance is the discovered service. For ServiceRemoved events it
+	// holds the last known state of the instance.
 	Instance ServiceInstance
 
-	// Addr is the resolved address of the service host.
+	// Addr is the resolved address of the service host. For
+	// ServiceRemoved events it holds the last known address.
 	Addr netip.Addr
 }
 

--- a/dns_sd.go
+++ b/dns_sd.go
@@ -28,30 +28,41 @@ var (
 	errUnhandledServiceQuestionType = errors.New("mDNS: unhandled DNS-SD question type")
 )
 
-// ServiceEventType identifies why a ServiceEvent was emitted.
+// ServiceEventType distinguishes DNS-SD service lifecycle events.
 type ServiceEventType uint8
 
 const (
 	// ServiceAdded indicates that a service instance was resolved for the first time.
 	ServiceAdded ServiceEventType = iota
+
 	// ServiceUpdated indicates that a resolved service instance changed while
 	// it was being continuously monitored.
 	//
 	// https://www.rfc-editor.org/rfc/rfc6762.html#section-5.2
 	ServiceUpdated
+
+	// ServiceRemoved indicates a previously reported instance is gone:
+	// its PTR record was withdrawn with a goodbye packet (RFC 6762 §10.1)
+	// or expired without being refreshed.
+	ServiceRemoved
 )
 
-// ServiceEvent represents a resolved DNS-SD service instance.
-// It is emitted by Browse when a complete service instance has been resolved
-// (PTR → SRV + TXT → address).
+// ServiceEvent represents a DNS-SD service lifecycle event observed
+// while browsing. A ServiceAdded event is emitted when a complete
+// service instance has been resolved (PTR → SRV + TXT → address); a
+// ServiceUpdated event when a monitored instance's records change; a
+// ServiceRemoved event when a previously reported instance leaves the
+// network.
 type ServiceEvent struct {
-	// Type identifies whether the service was added or updated.
+	// Type is the kind of event. The zero value is ServiceAdded.
 	Type ServiceEventType
 
-	// Instance is the discovered service.
+	// Instance is the discovered service. For ServiceRemoved events it
+	// holds the last known state of the instance.
 	Instance ServiceInstance
 
-	// Addr is the resolved address of the service host.
+	// Addr is the resolved address of the service host. For
+	// ServiceRemoved events it holds the last known address.
 	Addr netip.Addr
 }
 

--- a/refresh_test.go
+++ b/refresh_test.go
@@ -414,6 +414,39 @@ func TestRefreshLoopSendsQuestions(t *testing.T) {
 	assert.Equal(t, dnsmessage.TypePTR, msg.Questions[0].Type)
 }
 
+// collectEvents returns an emit callback that records events, plus an
+// accessor returning a snapshot of everything emitted so far.
+func collectEvents() (func(ServiceEvent), func() []ServiceEvent) {
+	var mu sync.Mutex
+	var events []ServiceEvent
+
+	emit := func(evt ServiceEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, evt)
+	}
+	snapshot := func() []ServiceEvent {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return append([]ServiceEvent(nil), events...)
+	}
+
+	return emit, snapshot
+}
+
+// feedInstance drives a browse session through a full PTR → SRV → TXT →
+// A resolution for one "_http._tcp" instance, triggering an emit.
+func feedInstance(t *testing.T, session *browseSession, instance, host, addr string) {
+	t.Helper()
+
+	fqdn := instance + "._http._tcp.local."
+	session.processRecord(mustBuildPTR(t, "_http._tcp.local.", fqdn, 4500), "")
+	session.processRecord(mustBuildSRV(t, fqdn, host, 8080, 120), "")
+	session.processRecord(mustBuildTXT(t, fqdn, []string{"path=/"}, 4500), "")
+	session.processRecord(mustBuildA(t, host, addr, 120), "")
+}
+
 // writerHasQuestion reports whether any packet captured by the writer
 // contains a question for the given name and type.
 func writerHasQuestion(writer *captureWriter, name string, qtype dnsmessage.Type) bool {

--- a/refresh_test.go
+++ b/refresh_test.go
@@ -414,6 +414,117 @@ func TestRefreshLoopSendsQuestions(t *testing.T) {
 	assert.Equal(t, dnsmessage.TypePTR, msg.Questions[0].Type)
 }
 
+// writerHasQuestion reports whether any packet captured by the writer
+// contains a question for the given name and type.
+func writerHasQuestion(writer *captureWriter, name string, qtype dnsmessage.Type) bool {
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+
+	for _, raw := range writer.packets {
+		var msg dnsmessage.Message
+		if msg.Unpack(raw) != nil {
+			continue
+		}
+
+		for _, question := range msg.Questions {
+			if strings.EqualFold(question.Name.String(), name) && question.Type == qtype {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func TestRefreshIncludesEmittedInstanceRecords(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	writer := &captureWriter{}
+	ca := newCache(time.Now)
+	cli := newClient(log, "test", writer, true, false, ca)
+
+	browse := newBrowseSession(t.Context(), "_http._tcp", func(ServiceEvent) {})
+	cli.handler.registerBrowseSession(browse)
+
+	// Resolve and emit one instance so it lands in the active set.
+	feedInstance(t, browse, "My Web", "myhost.local.", "192.168.1.100")
+
+	// Insert the instance's records already past the first refresh
+	// threshold. Before emitted instances were monitored, these would
+	// never be refreshed and would expire silently.
+	past := time.Now().Add(-99 * time.Second)
+	ca.insert(mustBuildSRV(t, "My Web._http._tcp.local.", "myhost.local.", 8080, 100), past)
+	ca.insert(mustBuildA(t, "myhost.local.", "192.168.1.100", 100), past)
+
+	conn := &Conn{
+		client:               cli,
+		cache:                ca,
+		stopBackground:       make(chan struct{}),
+		cacheRefresh:         true,
+		refreshCheckInterval: 10 * time.Millisecond,
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		conn.refreshLoop()
+	}()
+
+	assert.Eventually(t, func() bool {
+		return writerHasQuestion(writer, "my web._http._tcp.local.", dnsmessage.TypeSRV) &&
+			writerHasQuestion(writer, "myhost.local.", dnsmessage.TypeA)
+	}, time.Second, 10*time.Millisecond)
+
+	close(conn.stopBackground)
+	<-done
+}
+
+func TestSweepLoopEmitsServiceRemoved(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	writer := &captureWriter{}
+	ca := newCache(time.Now)
+	cli := newClient(log, "test", writer, true, false, ca)
+
+	emit, events := collectEvents()
+	browse := newBrowseSession(t.Context(), "_http._tcp", emit)
+	cli.handler.registerBrowseSession(browse)
+	feedInstance(t, browse, "My Web", "myhost.local.", "192.168.1.100")
+
+	// The instance PTR expired one second ago: the sweep loop must
+	// collect it and drive a ServiceRemoved event.
+	ca.insert(
+		mustBuildPTR(t, "_http._tcp.local.", "My Web._http._tcp.local.", 1),
+		time.Now().Add(-2*time.Second),
+	)
+
+	conn := &Conn{
+		client:         cli,
+		cache:          ca,
+		stopBackground: make(chan struct{}),
+		sweepInterval:  10 * time.Millisecond,
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		conn.sweepLoop()
+	}()
+
+	assert.Eventually(t, func() bool {
+		for _, evt := range events() {
+			if evt.Type == ServiceRemoved && evt.Instance.Instance == "My Web" {
+				return true
+			}
+		}
+
+		return false
+	}, time.Second, 10*time.Millisecond)
+
+	close(conn.stopBackground)
+	<-done
+}
+
 func TestSweepLoopRemovesExpired(t *testing.T) {
 	ca := newCache(time.Now)
 

--- a/server.go
+++ b/server.go
@@ -263,6 +263,12 @@ type serverConfig struct {
 	// For WebRTC/ICE legacy behavior, set to {dnsmessage.TypeA, dnsmessage.TypeAAAA}.
 	allowedRecordTypes []dnsmessage.Type
 
+	// serviceEventTypes limits which ServiceEvent types are delivered to
+	// the OnServiceEvent handler. If empty (default), all event types are
+	// delivered. The legacy Server constructor sets {ServiceAdded} so
+	// pre-existing handlers never see removal events.
+	serviceEventTypes []ServiceEventType
+
 	// responseTTL is the TTL (in seconds) for DNS response records.
 	// Defaults to 120 seconds per RFC 6762 recommendation.
 	responseTTL uint32
@@ -336,6 +342,7 @@ func NewServer(
 		stopBackground:       make(chan struct{}),
 		cacheRefresh:         cfg.cacheRefresh,
 		refreshCheckInterval: cfg.refreshCheckInterval,
+		serviceEventTypes:    cfg.serviceEventTypes,
 		closed:               make(chan any),
 	}
 	conn.name = cfg.name
@@ -598,6 +605,9 @@ func Server(
 		WithRecordTypes(dnsmessage.TypeA, dnsmessage.TypeAAAA),
 		// Legacy behavior: no proactive cache refresh.
 		WithCacheRefresh(false),
+		// Legacy behavior: deliver only ServiceAdded events; code written
+		// before removal events existed never sees other event types.
+		WithServiceEventTypes(ServiceAdded),
 	}
 	if config.Name != "" {
 		opts = append(opts, WithName(config.Name))

--- a/server.go
+++ b/server.go
@@ -359,6 +359,12 @@ type serverConfig struct {
 	// For WebRTC/ICE legacy behavior, set to {dnsmessage.TypeA, dnsmessage.TypeAAAA}.
 	allowedRecordTypes []dnsmessage.Type
 
+	// serviceEventTypes limits which ServiceEvent types are delivered to
+	// the OnServiceEvent handler. If empty (default), all event types are
+	// delivered. The legacy Server constructor sets {ServiceAdded} so
+	// pre-existing handlers never see removal events.
+	serviceEventTypes []ServiceEventType
+
 	// responseTTL is the TTL (in seconds) for DNS response records.
 	// Defaults to 120 seconds per RFC 6762 recommendation.
 	responseTTL uint32
@@ -432,6 +438,7 @@ func NewServer(
 		stopBackground:       make(chan struct{}),
 		cacheRefresh:         cfg.cacheRefresh,
 		refreshCheckInterval: cfg.refreshCheckInterval,
+		serviceEventTypes:    cfg.serviceEventTypes,
 		closed:               make(chan any),
 	}
 	conn.name = cfg.name
@@ -694,6 +701,9 @@ func Server(
 		WithRecordTypes(dnsmessage.TypeA, dnsmessage.TypeAAAA),
 		// Legacy behavior: no proactive cache refresh.
 		WithCacheRefresh(false),
+		// Legacy behavior: deliver only ServiceAdded events; code written
+		// before removal events existed never sees other event types.
+		WithServiceEventTypes(ServiceAdded),
 	}
 	if config.Name != "" {
 		opts = append(opts, WithName(config.Name))

--- a/server.go
+++ b/server.go
@@ -362,7 +362,7 @@ type serverConfig struct {
 	// serviceEventTypes limits which ServiceEvent types are delivered to
 	// the OnServiceEvent handler. If empty (default), all event types are
 	// delivered. The legacy Server constructor sets {ServiceAdded} so
-	// pre-existing handlers never see removal events.
+	// pre-existing handlers never see update or removal events.
 	serviceEventTypes []ServiceEventType
 
 	// responseTTL is the TTL (in seconds) for DNS response records.
@@ -702,7 +702,7 @@ func Server(
 		// Legacy behavior: no proactive cache refresh.
 		WithCacheRefresh(false),
 		// Legacy behavior: deliver only ServiceAdded events; code written
-		// before removal events existed never sees other event types.
+		// before update and removal events existed never sees them.
 		WithServiceEventTypes(ServiceAdded),
 	}
 	if config.Name != "" {


### PR DESCRIPTION
Browse so far only ever said hello: an instance was reported once, its records silently fell out of cache monitoring, and a service that left the network stayed in the consumer's view forever. Any real browse UI or discovery loop needs the goodbye too.

- `ServiceEvent.Type` distinguishes `ServiceAdded` from `ServiceRemoved`, fired on goodbye (RFC 6762 §10.1) or unrefreshed expiry of the instance PTR. Returning instances are re-reported as fresh adds.
- Emitted instances now stay in cache refresh (§5.2); previously they expired silently right after the first report.
- Backward compat is constructor-scoped, same pattern as #255's `WithRecordTypes`/`WithCacheRefresh` defaults: new `WithServiceEventTypes` option, and legacy `Server()` defaults to `ServiceAdded` only, so pre-existing code never sees the new event type. `compat_test.go` pins the whole legacy contract.
- `OnServiceEvent` replaces `OnServiceDiscovered` (deprecated alias kept): the stream carries lifecycle events now, not just discoveries.

Design: one removal pathway. Goodbyes are retained 1s in the cache and both goodbye and natural expiry surface through `sweep()`, which now returns what it removed. Removal is driven by the instance PTR only; cache-flush rdata replacement (§10.2) and cap evictions don't emit events. Also fixes a phantom pending instance created by goodbye PTRs for unknown instances.

Part of #253 (Phase 5).
