### PR TITLE
Only require IPv6 zone for link-local answers

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -459,8 +459,10 @@ func TestValidCommunicationIPv6(t *testing.T) { //nolint:cyclop
 
 	assert.NotEqualf(t, localAddress, addr.String(), "unexpected local address: %v", addr)
 	checkIPv6(t, addr)
-	if !addr.Is4In6() {
-		assert.NotEqualf(t, "", addr.Zone(), "expected IPv6 to have zone but got %s", addr)
+	// addrWithOptionalZone only attaches a zone to link-local addresses, so a ULA or
+	// globally routable answer legitimately has an empty zone.
+	if !addr.Is4In6() && (addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast()) {
+		assert.NotEqualf(t, "", addr.Zone(), "expected link-local IPv6 to have zone but got %s", addr)
 	}
 
 	assert.NoError(t, aServer.Close())


### PR DESCRIPTION
#### Description

`addrWithOptionalZone` only attaches a zone to link-local IPv6 addresses, so a ULA or globally routable answer legitimately has an empty zone. The second zone assertion in `TestValidCommunicationIPv6` still required a zone for every non-4in6 address, so the test failed whenever the operating system returned a non-link-local address first — the intermittent failure described in #225.

The first assertion in the same test was already guarded with a link-local check in 0073f11. This applies the same guard to the second one, so the zone requirement is kept where it is meaningful.

Of the two options listed in #225 this is option 1 (relax the test expectation rather than change address selection); it matches the guard already present a few lines above.

Verified with `gofmt -l .` (clean), `go build ./...`, `go vet ./...` and `go test -race -count=1 ./...` (all pass). Note that `TestValidCommunicationIPv6` is skipped on macOS by `skipIPv6MulticastOnDarwin`, so the original flake could not be reproduced locally; the change relies on the zone semantics of `addrWithOptionalZone`.

#### Reference issue
Fixes #225
