### PR TITLE
Add DNS-SD TXT update support

### DIFF
--- a/client.go
+++ b/client.go
@@ -425,7 +425,7 @@ type browseSession struct {
 	serviceType string // e.g. "_http._tcp"
 	domain      string // e.g. "local"
 	emit        func(ServiceEvent)
-	seen        map[string]bool             // instance names already emitted
+	seen        map[string]ServiceEvent     // last event emitted for each instance
 	pending     map[string]*pendingInstance // instances being assembled
 	mu          sync.Mutex
 	done        chan struct{}
@@ -446,7 +446,7 @@ func newBrowseSession(ctx context.Context, serviceType string, emit func(Service
 		serviceType: serviceType,
 		domain:      "local",
 		emit:        emit,
-		seen:        make(map[string]bool),
+		seen:        make(map[string]ServiceEvent),
 		pending:     make(map[string]*pendingInstance),
 		done:        done,
 		cancel:      cancel,
@@ -542,11 +542,10 @@ func (bs *browseSession) handlePTRRecord(answer dnsmessage.Resource) {
 		return
 	}
 
-	if bs.seen[instance] {
-		return
-	}
-
 	if _, exists := bs.pending[instance]; !exists {
+		if _, seen := bs.seen[instance]; seen {
+			return
+		}
 		bs.pending[instance] = &pendingInstance{
 			instance: instance,
 			service:  service,
@@ -640,26 +639,49 @@ func (bs *browseSession) findPendingByInstanceName(name string) *pendingInstance
 	return nil
 }
 
-// tryEmit fires the callback if the instance is complete and not yet emitted.
+// tryEmit fires the callback when a complete instance is first resolved or changes.
 func (bs *browseSession) tryEmit(inst *pendingInstance, zone string) bool {
 	if !inst.isComplete() {
 		return false
 	}
-	if bs.seen[inst.instance] {
-		return false
-	}
-
-	bs.seen[inst.instance] = true
 
 	if zone != "" {
 		inst.addr = addrWithOptionalZone(inst.addr, zone)
 	}
 
 	evt := inst.toServiceEvent()
-	bs.emit(evt)
-	delete(bs.pending, inst.instance)
+	previous, seen := bs.seen[inst.instance]
+	if seen && serviceEventsEqual(previous, evt) {
+		return false
+	}
+	if seen {
+		evt.Type = ServiceUpdated
+	} else {
+		evt.Type = ServiceAdded
+	}
+	bs.seen[inst.instance] = cloneServiceEvent(evt)
+	bs.emit(cloneServiceEvent(evt))
 
 	return true
+}
+
+func serviceEventsEqual(a, b ServiceEvent) bool {
+	return a.Addr == b.Addr &&
+		a.Instance.Instance == b.Instance.Instance &&
+		a.Instance.Service == b.Instance.Service &&
+		a.Instance.Domain == b.Instance.Domain &&
+		a.Instance.Host == b.Instance.Host &&
+		a.Instance.Port == b.Instance.Port &&
+		a.Instance.Priority == b.Instance.Priority &&
+		a.Instance.Weight == b.Instance.Weight &&
+		txtEntriesEqual(a.Instance.Text, b.Instance.Text)
+}
+
+func cloneServiceEvent(evt ServiceEvent) ServiceEvent {
+	cloned := evt
+	cloned.Instance.Text = cloneTXTEntries(evt.Instance.Text)
+
+	return cloned
 }
 
 // enumerateSession tracks the state of an active EnumerateServiceTypes call.

--- a/client_test.go
+++ b/client_test.go
@@ -1055,3 +1055,50 @@ func TestEnumerateSessionMonitoredKeys(t *testing.T) {
 	assert.Equal(t, "_services._dns-sd._udp.local.", keys[0].name)
 	assert.Equal(t, dnsmessage.TypePTR, keys[0].rrType)
 }
+
+func TestBrowseSessionTXTUpdate(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+	handler := newAnswerHandler(log, "test", newCache(time.Now))
+
+	var events []ServiceEvent
+	session := newBrowseSession(t.Context(), "_http._tcp", func(evt ServiceEvent) {
+		events = append(events, evt)
+	})
+	handler.registerBrowseSession(session)
+	defer handler.unregisterBrowseSession(session)
+
+	msgCtx := &messageContext{
+		source:    &net.UDPAddr{IP: net.IPv4(192, 168, 1, 1), Port: 5353},
+		ifIndex:   1,
+		timestamp: time.Now(),
+	}
+	handler.handle(msgCtx, buildBrowseResponseMsg(t))
+	events[0].Instance.Text[0].Value = []byte("consumer-mutated")
+	handler.handle(msgCtx, buildBrowseResponseMsg(t))
+	require.Len(t, events, 1)
+
+	update := &dnsmessage.Message{
+		Header: dnsmessage.Header{Response: true, Authoritative: true},
+		Answers: []dnsmessage.Resource{
+			{
+				Header: dnsmessage.ResourceHeader{
+					Name:  dnsmessage.MustNewName("My Web._http._tcp.local."),
+					Type:  dnsmessage.TypeTXT,
+					Class: dnsmessage.ClassINET | rrClassCacheFlush,
+					TTL:   4500,
+				},
+				Body: &dnsmessage.TXTResource{TXT: []string{"path=/new", "version=2"}},
+			},
+		},
+	}
+	handler.handle(msgCtx, update)
+	handler.handle(msgCtx, update)
+
+	require.Len(t, events, 2)
+	assert.Equal(t, ServiceAdded, events[0].Type)
+	assert.Equal(t, ServiceUpdated, events[1].Type)
+	assert.Equal(t, []TXTEntry{
+		NewTXTString("path", "/new"),
+		NewTXTString("version", "2"),
+	}, events[1].Instance.Text)
+}

--- a/conn.go
+++ b/conn.go
@@ -186,6 +186,56 @@ func (c *Conn) Register(svc ServiceInstance) error {
 	return nil
 }
 
+// UpdateTXT replaces the TXT data of a registered DNS-SD service and
+// immediately announces the new record. The instance is identified by its
+// Instance name and Service type.
+//
+// https://www.rfc-editor.org/rfc/rfc6762.html#section-8.4
+// https://www.rfc-editor.org/rfc/rfc6762.html#section-10.2
+func (c *Conn) UpdateTXT(instance, service string, text []TXTEntry) error {
+	select {
+	case <-c.closed:
+		return errConnectionClosed
+	default:
+	}
+
+	if c.server == nil {
+		return errConnectionClosed
+	}
+
+	if err := validateInstanceName(instance); err != nil {
+		return err
+	}
+	if err := validateServiceName(service); err != nil {
+		return err
+	}
+	if err := validateTXTEntries(text); err != nil {
+		return err
+	}
+
+	generation, err := c.server.updateTXT(instance, service, text)
+	if err != nil || generation == 0 {
+		return err
+	}
+
+	go c.repeatTXTAnnouncement(instance, service, generation)
+
+	return nil
+}
+
+func (c *Conn) repeatTXTAnnouncement(instance, service string, generation uint64) {
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		if err := c.server.repeatTXTAnnouncement(instance, service, generation); err != nil {
+			c.log.Warnf("[%s] failed to repeat TXT announcement: %v", c.name, err)
+		}
+	case <-c.closed:
+	}
+}
+
 // Unregister removes a DNS-SD service instance from the server.
 // The instance is identified by its Instance name and Service type.
 func (c *Conn) Unregister(instance, service string) {

--- a/dns_sd.go
+++ b/dns_sd.go
@@ -28,10 +28,26 @@ var (
 	errUnhandledServiceQuestionType = errors.New("mDNS: unhandled DNS-SD question type")
 )
 
-// ServiceEvent represents a discovered DNS-SD service instance.
+// ServiceEventType identifies why a ServiceEvent was emitted.
+type ServiceEventType uint8
+
+const (
+	// ServiceAdded indicates that a service instance was resolved for the first time.
+	ServiceAdded ServiceEventType = iota
+	// ServiceUpdated indicates that a resolved service instance changed while
+	// it was being continuously monitored.
+	//
+	// https://www.rfc-editor.org/rfc/rfc6762.html#section-5.2
+	ServiceUpdated
+)
+
+// ServiceEvent represents a resolved DNS-SD service instance.
 // It is emitted by Browse when a complete service instance has been resolved
 // (PTR → SRV + TXT → address).
 type ServiceEvent struct {
+	// Type identifies whether the service was added or updated.
+	Type ServiceEventType
+
 	// Instance is the discovered service.
 	Instance ServiceInstance
 

--- a/errors.go
+++ b/errors.go
@@ -9,6 +9,7 @@ var (
 	errJoiningMulticastGroup = errors.New("mDNS: failed to join multicast group")
 	errConnectionClosed      = errors.New("mDNS: connection is closed")
 	errContextElapsed        = errors.New("mDNS: context has elapsed")
+	errServiceNotFound       = errors.New("mDNS: service is not registered")
 	errNilConfig             = errors.New("mDNS: config must not be nil")
 	errFailedCast            = errors.New("mDNS: failed to cast listener to UDPAddr")
 )

--- a/records.go
+++ b/records.go
@@ -4,12 +4,36 @@
 package mdns
 
 import (
+	"bytes"
 	"errors"
 	"net/netip"
 	"strings"
 
 	"golang.org/x/net/dns/dnsmessage"
 )
+
+func cloneTXTEntries(entries []TXTEntry) []TXTEntry {
+	cloned := make([]TXTEntry, len(entries))
+	for i := range entries {
+		cloned[i] = TXTEntry{Key: entries[i].Key, Value: bytes.Clone(entries[i].Value)}
+	}
+
+	return cloned
+}
+
+func txtEntriesEqual(a, b []TXTEntry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i].Key != b[i].Key || !bytes.Equal(a[i].Value, b[i].Value) {
+			return false
+		}
+	}
+
+	return true
+}
 
 // browseTTL is the recommended TTL for non-host-scoped records (browsing PTR,
 // TXT) per RFC 6762 §10: 75 minutes = 4500 seconds.

--- a/server.go
+++ b/server.go
@@ -132,8 +132,15 @@ type server struct {
 	writer  answerWriter
 	ttl     uint32
 
-	mu       sync.RWMutex
-	services []ServiceInstance
+	mu                         sync.RWMutex
+	services                   []ServiceInstance
+	txtAnnouncementGeneration  uint64
+	txtAnnouncementGenerations map[registeredServiceKey]uint64
+}
+
+type registeredServiceKey struct {
+	instance string
+	service  string
 }
 
 // newServer creates a new mDNS server.
@@ -182,6 +189,94 @@ func (s *server) registerService(svc ServiceInstance) {
 	s.services = append(s.services, svc)
 }
 
+// updateTXT replaces a registered service's TXT data and sends the first
+// cache-flushed announcement.
+// https://www.rfc-editor.org/rfc/rfc6762.html#section-8.3
+func (s *server) updateTXT(instance, service string, text []TXTEntry) (uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i := range s.services {
+		if s.services[i].Instance != instance || s.services[i].Service != service {
+			continue
+		}
+		if txtEntriesEqual(s.services[i].Text, text) {
+			return 0, nil
+		}
+
+		updated := s.services[i]
+		updated.Text = cloneTXTEntries(text)
+
+		txtStrings, err := encodeTXTRecordStrings(updated.Text)
+		if err != nil {
+			return 0, err
+		}
+		rawAnnouncement, err := s.packTXTAnnouncement(&updated, txtStrings)
+		if err != nil {
+			return 0, err
+		}
+
+		s.txtAnnouncementGeneration++
+		if s.txtAnnouncementGeneration == 0 {
+			s.txtAnnouncementGeneration++
+		}
+		if s.txtAnnouncementGenerations == nil {
+			s.txtAnnouncementGenerations = make(map[registeredServiceKey]uint64)
+		}
+		generation := s.txtAnnouncementGeneration
+		s.txtAnnouncementGenerations[registeredServiceKey{instance: instance, service: service}] = generation
+
+		s.services[i] = updated
+		s.writer.writeAnswer(-1, rawAnnouncement, false, false, nil)
+
+		return generation, nil
+	}
+
+	return 0, errServiceNotFound
+}
+
+func (s *server) repeatTXTAnnouncement(instance, service string, generation uint64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := registeredServiceKey{instance: instance, service: service}
+	if s.txtAnnouncementGenerations[key] != generation {
+		return nil
+	}
+	for i := range s.services {
+		if s.services[i].Instance != instance || s.services[i].Service != service {
+			continue
+		}
+
+		txtStrings, err := encodeTXTRecordStrings(s.services[i].Text)
+		if err != nil {
+			return err
+		}
+		rawAnnouncement, err := s.packTXTAnnouncement(&s.services[i], txtStrings)
+		if err != nil {
+			return err
+		}
+		s.writer.writeAnswer(-1, rawAnnouncement, false, false, nil)
+
+		return nil
+	}
+
+	return nil
+}
+
+func (s *server) packTXTAnnouncement(svc *ServiceInstance, txtStrings []string) ([]byte, error) {
+	txtRecord, err := buildTXTResource(svc.serviceInstanceName(), txtStrings, s.ttl)
+	if err != nil {
+		return nil, err
+	}
+	txtRecord.Header.Class |= rrClassCacheFlush
+
+	return (&dnsmessage.Message{
+		Header:  dnsmessage.Header{Response: true, Authoritative: true},
+		Answers: []dnsmessage.Resource{txtRecord},
+	}).Pack()
+}
+
 // unregisterService removes a DNS-SD service from the server by instance+service match.
 func (s *server) unregisterService(instance, service string) {
 	s.mu.Lock()
@@ -190,6 +285,7 @@ func (s *server) unregisterService(instance, service string) {
 	for i := len(s.services) - 1; i >= 0; i-- {
 		if s.services[i].Instance == instance && s.services[i].Service == service {
 			s.services = append(s.services[:i], s.services[i+1:]...)
+			delete(s.txtAnnouncementGenerations, registeredServiceKey{instance: instance, service: service})
 
 			return
 		}

--- a/server_test.go
+++ b/server_test.go
@@ -1024,6 +1024,95 @@ func TestServerUnregisterNonExistent(t *testing.T) {
 	assert.Len(t, srv.getServices(), 1, "should not remove non-matching service")
 }
 
+func TestServerUpdateTXT(t *testing.T) {
+	writer := &mockAnswerWriter{}
+	srv := &server{ttl: 120, writer: writer}
+	srv.registerService(ServiceInstance{
+		Instance: "Test",
+		Service:  "_http._tcp",
+		Domain:   "local",
+		Host:     "test.local.",
+		Port:     80,
+		Text:     []TXTEntry{NewTXTString("version", "1")},
+	})
+
+	generation, err := srv.updateTXT("Test", "_http._tcp", []TXTEntry{NewTXTString("version", "2")})
+	require.NoError(t, err)
+	assert.NotZero(t, generation)
+	require.Len(t, srv.getServices(), 1)
+	assert.Equal(t, []TXTEntry{NewTXTString("version", "2")}, srv.getServices()[0].Text)
+
+	require.Len(t, writer.writtenAnswers, 1)
+	var msg dnsmessage.Message
+	require.NoError(t, msg.Unpack(writer.writtenAnswers[0]))
+	require.Len(t, msg.Answers, 1)
+	assert.True(t, msg.Header.Response)
+	assert.True(t, msg.Header.Authoritative)
+	assert.Equal(t, dnsmessage.TypeTXT, msg.Answers[0].Header.Type)
+	assert.NotZero(t, msg.Answers[0].Header.Class&rrClassCacheFlush)
+
+	txts, err := parseTXTData(msg.Answers[0].Body)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"version=2"}, txts)
+
+	unchangedGeneration, err := srv.updateTXT("Test", "_http._tcp", []TXTEntry{NewTXTString("version", "2")})
+	require.NoError(t, err)
+	assert.Zero(t, unchangedGeneration)
+	assert.Len(t, writer.writtenAnswers, 1)
+
+	require.NoError(t, srv.repeatTXTAnnouncement("Test", "_http._tcp", generation))
+	assert.Len(t, writer.writtenAnswers, 2)
+}
+
+func TestServerUpdateTXTServiceNotFound(t *testing.T) {
+	srv := &server{writer: &mockAnswerWriter{}}
+
+	_, err := srv.updateTXT("Missing", "_http._tcp", nil)
+	assert.ErrorIs(t, err, errServiceNotFound)
+}
+
+func TestServerUpdateTXTSupersedesRepeatedAnnouncement(t *testing.T) {
+	writer := &mockAnswerWriter{}
+	srv := &server{ttl: 120, writer: writer}
+	srv.registerService(ServiceInstance{
+		Instance: "Test",
+		Service:  "_http._tcp",
+		Domain:   "local",
+	})
+
+	first, err := srv.updateTXT("Test", "_http._tcp", []TXTEntry{NewTXTString("version", "1")})
+	require.NoError(t, err)
+	second, err := srv.updateTXT("Test", "_http._tcp", []TXTEntry{NewTXTString("version", "2")})
+	require.NoError(t, err)
+	require.NoError(t, srv.repeatTXTAnnouncement("Test", "_http._tcp", first))
+	require.NoError(t, srv.repeatTXTAnnouncement("Test", "_http._tcp", second))
+
+	assert.Len(t, writer.writtenAnswers, 3)
+}
+
+func TestServerUnregisterCancelsTXTRepeat(t *testing.T) {
+	writer := &mockAnswerWriter{}
+	srv := &server{ttl: 120, writer: writer}
+	srv.registerService(ServiceInstance{
+		Instance: "Test",
+		Service:  "_http._tcp",
+		Domain:   "local",
+	})
+
+	generation, err := srv.updateTXT("Test", "_http._tcp", []TXTEntry{NewTXTString("version", "1")})
+	require.NoError(t, err)
+	srv.unregisterService("Test", "_http._tcp")
+	srv.registerService(ServiceInstance{
+		Instance: "Test",
+		Service:  "_http._tcp",
+		Domain:   "local",
+		Text:     []TXTEntry{NewTXTString("version", "2")},
+	})
+
+	require.NoError(t, srv.repeatTXTAnnouncement("Test", "_http._tcp", generation))
+	assert.Len(t, writer.writtenAnswers, 1)
+}
+
 // ---------------------------------------------------------------------------
 // DNS-SD: createServiceAnswer
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
#### Description
Adds dns-sd TXT update support as described in RFC-6762 I need this for a small DTLS demo (used this to test against the demo locally).